### PR TITLE
Replace the dns-sd browse API to Network framework Browse API

### DIFF
--- a/src/platform/Darwin/BUILD.gn
+++ b/src/platform/Darwin/BUILD.gn
@@ -61,6 +61,8 @@ static_library("Darwin") {
     "DnssdImpl.h",
     "InetPlatformConfig.h",
     "Logging.cpp",
+    "MDnsProviderCpp.cpp",
+    "MDnsProviderCpp.h",
     "MdnsError.cpp",
     "MdnsError.h",
     "NetworkCommissioningDriver.h",

--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -481,5 +481,41 @@ InterfaceInfo::~InterfaceInfo()
     Platform::MemoryFree(const_cast<TextEntry *>(service.mTextEntries));
 }
 
+DnsProviderBrowseContext::DnsProviderBrowseContext()
+{
+}
+
+DnsProviderBrowseContext::~DnsProviderBrowseContext()
+{
+    MDnsProviderDelete(provider);
+}
+
+CHIP_ERROR DnsProviderBrowseContext::Finalize(int err)
+{
+    MDnsProviderStopBrowsing(provider);
+
+    if (!err)
+    {
+        DispatchSuccess();
+    }
+    else
+    {
+        DispatchFailure(err);   
+    }
+
+    delete(this);
+}
+
+void DnsProviderBrowseContext::DispatchFailure(int err)
+{
+    ChipLogError(Discovery, "Mdns: Browse failure (%s)", Error::ToString(err));
+    callback(context, nullptr, 0, true, Error::ToChipError(err));
+}
+
+void DnsProviderBrowseContext::DispatchSuccess()
+{
+    callback(context, services.data(), services.size(), true, CHIP_NO_ERROR);
+}
+
 } // namespace Dnssd
 } // namespace chip

--- a/src/platform/Darwin/DnssdImpl.h
+++ b/src/platform/Darwin/DnssdImpl.h
@@ -21,6 +21,7 @@
 #include <lib/dnssd/platform/Dnssd.h>
 
 #include "DnssdHostNameRegistrar.h"
+#include "MDnsProviderCpp.h"
 
 #include <map>
 #include <string>
@@ -117,6 +118,23 @@ struct BrowseContext : public GenericContext
 
     void DispatchFailure(DNSServiceErrorType err) override;
     void DispatchSuccess() override;
+};
+
+struct DnsProviderBrowseContext
+{
+    std::vector<DnssdService> services;
+    DnssdBrowseCallback callback;
+    uint32_t interfaceId;
+    DnssdServiceProtocol protocol;
+    MDnsProvider* provider;
+    void* context;
+
+    DnsProviderBrowseContext();
+    ~DnsProviderBrowseContext();
+
+    CHIP_ERROR Finalize(int err = 0);
+    void DispatchFailure(int err);
+    void DispatchSuccess();
 };
 
 struct InterfaceInfo

--- a/src/platform/Darwin/MDnsProviderCpp.cpp
+++ b/src/platform/Darwin/MDnsProviderCpp.cpp
@@ -1,0 +1,196 @@
+//
+//  MDnsProviderCpp.c
+//  MDNS-SD
+//
+//  Created by Hilal, Rawad on 2/15/23.
+//
+
+#include "MDnsProviderCpp.h"
+#include <Network/Network.h>
+#include <lib/support/CHIPMem.h>
+
+namespace chip {
+namespace Dnssd {
+    
+typedef struct MDnsProvider
+{
+    nw_browser_t                browser;
+    MDnsProviderState           state;
+    nw_browse_descriptor_t      browse_descriptor;
+    nw_parameters_t             browse_parameters;
+    MDnsProviderStateHandler    state_handler;
+    void*                       state_handler_context;
+    MDnsProviderBrowseHandler   browse_handler;
+    void*                       browse_handler_context;
+}MDnsProvider;
+    
+void _MDnsProviderInitializeBrowser(MDnsProvider* provider);
+
+MDnsProvider* MDnsProviderCreate(const char* service_type, const char* domain)
+{
+    MDnsProvider* provider = chip::Platform::New<MDnsProvider>();
+    
+    provider->browser = NULL;
+    provider->state = NOT_RUNNING;
+    provider->browse_descriptor = nw_browse_descriptor_create_bonjour_service(service_type, domain);
+    provider->browse_parameters = nw_parameters_create();
+    provider->state_handler = NULL;
+    provider->state_handler_context = NULL;
+    provider->browse_handler = NULL;
+    provider->browse_handler_context = NULL;
+    
+    return provider;
+}
+
+void MDnsProviderDelete(MDnsProvider* provider)
+{
+    assert(provider != NULL);
+    
+    provider->state_handler = NULL;
+    provider->browse_handler = NULL;
+    
+    if (provider->browser != NULL)
+    {
+        MDnsProviderStopBrowsing(provider);
+    }
+    
+    nw_release(provider->browse_descriptor);
+    nw_release(provider->browse_parameters);
+    
+    chip::Platform::Delete(provider);
+}
+
+void MDnsProviderSetStateHandler(MDnsProvider* provider, MDnsProviderStateHandler handler, void* context)
+{
+    provider->state_handler = handler;
+    provider->state_handler_context = context;
+}
+
+void MDnsProviderSetBrowseHandler(MDnsProvider* provider, MDnsProviderBrowseHandler handler, void* context)
+{
+    provider->browse_handler = handler;
+    provider->browse_handler_context = context;
+}
+
+void MDnsProviderStartBrowsing(MDnsProvider* provider)
+{
+    if (provider->state == RUNNING || provider->state == STARTING)
+    {
+        return;
+    }
+    
+    provider->state = STARTING;
+    
+    _MDnsProviderInitializeBrowser(provider);
+    nw_browser_start(provider->browser);
+}
+
+void MDnsProviderStopBrowsing(MDnsProvider* provider)
+{
+    if (provider->state != RUNNING && provider->state != STARTING)
+    {
+        return;
+    }
+    
+    if (provider->browser == NULL)
+    {
+        return;
+    }
+    
+    nw_browser_set_state_changed_handler(provider->browser, NULL);
+    nw_browser_set_browse_results_changed_handler(provider->browser, NULL);
+    nw_browser_cancel(provider->browser);
+    nw_release(provider->browser);
+    
+    provider->state = NOT_RUNNING;
+    provider->browser = NULL;
+}
+
+void _MDnsProviderInitializeBrowser(MDnsProvider* provider)
+{
+    provider->browser = nw_browser_create(provider->browse_descriptor, provider->browse_parameters);
+    nw_retain(provider->browser);
+    
+    nw_browser_set_queue(provider->browser, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0));
+    nw_browser_set_state_changed_handler(provider->browser, ^(nw_browser_state_t state, nw_error_t  _Nullable error) {
+        int error_code = 0;
+        MDnsProviderState dns_provider_state = NOT_RUNNING;
+        switch (state) {
+            case nw_browser_state_ready:
+            case nw_browser_state_waiting:
+                dns_provider_state = RUNNING;
+                break;
+            case nw_browser_state_failed:
+            case nw_browser_state_invalid:
+                dns_provider_state = FAILED;
+                nw_release(provider->browser);
+                break;
+            case nw_browser_state_cancelled:
+                dns_provider_state = NOT_RUNNING;
+                nw_release(provider->browser);
+                break;
+            default:
+                break;
+        }
+        provider->state = dns_provider_state;
+        if (error != NULL)
+        {
+            error_code = nw_error_get_error_code(error);
+        }
+        
+        if (provider->state_handler != NULL)
+        {
+            provider->state_handler(provider, dns_provider_state, error_code, provider->state_handler_context);
+        }
+    });
+    
+    nw_browser_set_browse_results_changed_handler(provider->browser, ^(nw_browse_result_t  _Nonnull old_result, nw_browse_result_t  _Nonnull new_result, bool batch_complete) {
+        
+        MDnsProviderBrowseFlags flags = 0;
+        nw_browse_result_t result = nil;
+        if (old_result && new_result)
+        {
+            result = new_result;
+            flags = flags | kMDnsProviderBrowseFlagsUpdate;
+        }
+        else if (old_result)
+        {
+            result = old_result;
+            flags = flags | kMDnsProviderBrowseFlagsRemove;
+        }
+        else if (new_result)
+        {
+            result = new_result;
+            flags = flags | kMDnsProviderBrowseFlagsAdd;
+        }
+        
+        nw_endpoint_t endpoint = nw_browse_result_copy_endpoint(result);
+        const char *name = nw_endpoint_get_bonjour_service_name(endpoint);
+        const char *type = nw_endpoint_get_bonjour_service_type(endpoint);
+        const char *domain = nw_endpoint_get_bonjour_service_domain(endpoint);
+        
+        __block size_t interface_count = nw_browse_result_get_interfaces_count(result);
+        
+        nw_browse_result_enumerate_interfaces(result, ^bool(nw_interface_t  _Nonnull interface) {
+            MDnsProviderBrowseFlags final_flags = flags;
+            
+            bool is_last_interface = (--interface_count == 0);
+            if (batch_complete && is_last_interface)
+            {
+                final_flags = final_flags | kMDnsProviderBrowseFlagsBatchComplete;
+            }
+            
+            uint32_t interface_id = nw_interface_get_index(interface);
+            
+            if (provider->browse_handler != NULL)
+            {
+                provider->browse_handler(
+                    provider, final_flags, name, type, domain, interface_id, provider->browse_handler_context);
+            }
+            return true;
+        });
+    });
+}
+    
+}
+}

--- a/src/platform/Darwin/MDnsProviderCpp.h
+++ b/src/platform/Darwin/MDnsProviderCpp.h
@@ -1,0 +1,133 @@
+//
+//  MDnsProviderCpp.h
+//  MDNS-SD
+//
+//  Created by Hilal, Rawad on 2/15/23.
+//
+
+#ifndef MDnsProviderCpp_hpp
+#define MDnsProviderCpp_hpp
+
+#include <stdio.h>
+#include <stdint.h>
+
+namespace chip {
+namespace Dnssd {
+
+/**
+  Reference to mDns provider.
+ */
+typedef struct MDnsProvider MDnsProvider;
+
+/**
+ Defines the state of the mDNS provider.
+ */
+typedef enum _MDnsProviderState
+{
+    /** The provider is not running. */
+    NOT_RUNNING,
+    /** The provider is initializing. */
+    STARTING,
+    /** The provider is running. */
+    RUNNING,
+    /** The provider failed. */
+    FAILED
+}MDnsProviderState;
+
+/**
+ * The handler that will be invoked when the state of the provider changes.
+ * @param provider The provider instance.
+ * @param state The provider state.
+ * @param error_code The error code associated to the failed state. 0 if no error.
+ * @param context The user-provided context object that is passed to DnsProviderSetStateHandler.
+ */
+typedef void (*MDnsProviderStateHandler)
+(
+ MDnsProvider* provider,
+ MDnsProviderState state,
+ int error_code,
+ void* context
+ );
+
+/**
+ * The various flags for the browse event.
+ * kDnsProviderBrowseFlagsAdd The endpoint was added since the last browse event.
+ * kDnsProviderBrowseFlagsRemove The endpoint was removed since the last browse event.
+ * kDnsProviderBrowseFlagsUpdate The endpoint was updated since the last browse event.
+ * kDnsProviderBrowseFlagsBatchComplete When set, the provider has no more immediate changes to
+ *        report to the user.
+ */
+enum _MDnsProviderBrowseFlags {
+    kMDnsProviderBrowseFlagsAdd              = 1,
+    kMDnsProviderBrowseFlagsRemove           = 1 << 1,
+    kMDnsProviderBrowseFlagsUpdate           = 1 << 2,
+    kMDnsProviderBrowseFlagsBatchComplete    = 1 << 3
+};
+typedef int MDnsProviderBrowseFlags;
+
+/**
+ * The handler that will be invoked when the provider finds an endpoint.
+ * @param provider The provider instance.
+ * @param flags The flags of the browse event. @see DnsProviderBrowseFlags.
+ * @param name Service name string for the endpoint.
+ * @param type Service type string for the endpoint.
+ * @param domain Domain string for the endpoint.
+ * @param interface_id Interface id of the endpoint.
+ * @param context The user-provided context object that is passed to DnsProviderSetStateHandler.
+ */
+typedef void (*MDnsProviderBrowseHandler)
+(
+ MDnsProvider* provider,
+ const MDnsProviderBrowseFlags flags,
+ const char* name,
+ const char* type,
+ const char* domain,
+ uint32_t interface_id,
+ void* context
+ );
+
+/**
+ * Create a mDNS provider.
+ * @param service_type The service type. Ex. _matterd._udp
+ * @param domain The domain. Ex. `local.`.
+ * @return The mDNS provider instance.
+ */
+MDnsProvider* MDnsProviderCreate(const char* service_type, const char* domain);
+
+/**
+ * Release the mDNS provider from memory.
+ * @param provider The mDNS provider.
+ */
+void MDnsProviderDelete(MDnsProvider* provider);
+
+/**
+ * Set the mDNS provider state handler.
+ * @param provider The mDNS provider.
+ * @param handler The handler.
+ * @param context The user context that will be provided as part of the callback.
+ */
+void MDnsProviderSetStateHandler(MDnsProvider* provider, MDnsProviderStateHandler handler, void* context);
+
+/**
+ * Set the mDNS provider browse handler.
+ * @param provider The mDNS provider.
+ * @param handler The handler.
+ * @param context The user context that will be provided as part of the callback.
+ */
+void MDnsProviderSetBrowseHandler(MDnsProvider* provider, MDnsProviderBrowseHandler handler, void* context);
+
+/**
+ * Start browsing.
+ * @param provider The mDNS provider.
+ */
+void MDnsProviderStartBrowsing(MDnsProvider* provider);
+
+/**
+ * Stop browsing.
+ * @param provider The mDNS provider.
+ */
+void MDnsProviderStopBrowsing(MDnsProvider* provider);
+
+}
+}
+#endif /* MDnsProviderCpp_hpp */


### PR DESCRIPTION
The implementation of DnssdImpl's DNSServiceBrowse() DNS-SD API on Darwin has proven to be unreliable on iOS. The API relies on an on-device daemon to handle query requests, returning cached data on a cache hit, and handling multicast query responses outside of the application process to update its local cache. However, even when the cache is hit, the API sometimes returns only some entries and other times returns all entries, regardless of whether query requests were made in between. For instance, on the first call, the API returned all three items, on the second call, only one item was returned, and on the third call, all three were returned. However, there were no query requests made during any of these calls, as confirmed by Wireshark. Therefore, during testing, the nw_browser_start API from the new Network framework proved to be much more reliable. As a result, the implementation was updated to use the nw_browser_start API instead.

