### PR TITLE
Adding a no-debug target into the tv apps

### DIFF
--- a/examples/tv-casting-app/android/README.md
+++ b/examples/tv-casting-app/android/README.md
@@ -81,6 +81,8 @@ the top Matter directory:
 ```shell
 ./scripts/build/build_examples.py --target android-arm64-tv-casting-app build
 ```
+(To build this app with no debugging hooks, use the
+`android-arm64-tv-casting-app-no-debug` target)
 
 See the table above for other values of `TARGET_CPU`.
 

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -490,8 +490,14 @@ def AndroidTargets():
     yield target.Extend('arm-tv-server', board=AndroidBoard.ARM, app=AndroidApp.TV_SERVER)
     yield target.Extend('x86-tv-server', board=AndroidBoard.X86, app=AndroidApp.TV_SERVER)
     yield target.Extend('x64-tv-server', board=AndroidBoard.X64, app=AndroidApp.TV_SERVER)
+    yield target.Extend('arm64-tv-server-no-debug', board=AndroidBoard.ARM64, app=AndroidApp.TV_SERVER, is_debug=False)
+    yield target.Extend('arm-tv-server-no-debug', board=AndroidBoard.ARM, app=AndroidApp.TV_SERVER, is_debug=False)
+    yield target.Extend('x86-tv-server-no-debug', board=AndroidBoard.X86, app=AndroidApp.TV_SERVER, is_debug=False)
+    yield target.Extend('x64-tv-server-no-debug', board=AndroidBoard.X64, app=AndroidApp.TV_SERVER, is_debug=False)
     yield target.Extend('arm64-tv-casting-app', board=AndroidBoard.ARM64, app=AndroidApp.TV_CASTING_APP)
     yield target.Extend('arm-tv-casting-app', board=AndroidBoard.ARM, app=AndroidApp.TV_CASTING_APP)
+    yield target.Extend('arm64-tv-casting-app-no-debug', board=AndroidBoard.ARM64, app=AndroidApp.TV_CASTING_APP, is_debug=False)
+    yield target.Extend('arm-tv-casting-app-no-debug', board=AndroidBoard.ARM, app=AndroidApp.TV_CASTING_APP, is_debug=False)
 
 
 def MbedTargets():

--- a/scripts/build/builders/android.py
+++ b/scripts/build/builders/android.py
@@ -334,7 +334,7 @@ class AndroidBuilder(Builder):
             gn_args["target_cpu"] = self.board.TargetCpuName()
             gn_args["android_ndk_root"] = os.environ["ANDROID_NDK_HOME"]
             gn_args["android_sdk_root"] = os.environ["ANDROID_HOME"]
-            if self.is_debug == False:
+            if self.is_debug is False:
                 gn_args["is_debug"] = False
             gn_args.update(self.app.AppGnArgs())
 

--- a/scripts/build/builders/android.py
+++ b/scripts/build/builders/android.py
@@ -457,7 +457,7 @@ class AndroidBuilder(Builder):
                     "tv-sever-platform-app-debug.apk": os.path.join(
                         self.output_dir, "platform-app", "outputs", "apk", "debug", "platform-app-debug.apk"
                     ),
-                    "tv-sever-content-app.apk": os.path.join(
+                    "tv-sever-content-app-debug.apk": os.path.join(
                         self.output_dir, "content-app", "outputs", "apk", "debug", "content-app-debug.apk"
                     )
                 }


### PR DESCRIPTION
The no-debug target significantly reduces the size of the binaries
