### PR TITLE
tv-casting-app: Allow for a way for Matter TV casting cache to be purged

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CommissionerDiscoveryFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CommissionerDiscoveryFragment.java
@@ -4,7 +4,7 @@ import android.content.Context;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
-import android.util.Log;;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -12,9 +12,11 @@ import android.widget.ArrayAdapter;
 import android.widget.Button;
 import android.widget.ListView;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
+
 import com.chip.casting.DiscoveredNodeData;
 import com.chip.casting.FailureCallback;
 import com.chip.casting.MatterError;
@@ -27,6 +29,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
+
+;
 
 /** A {@link Fragment} to discover commissioners on the network */
 public class CommissionerDiscoveryFragment extends Fragment {
@@ -78,6 +82,19 @@ public class CommissionerDiscoveryFragment extends Fragment {
         View.OnClickListener manualCommissioningButtonOnClickListener =
             v -> callback.handleCommissioningButtonClicked(null);
         manualCommissioningButton.setOnClickListener(manualCommissioningButtonOnClickListener);
+
+
+        Button purgeCacheButton = getView().findViewById(R.id.purgeCacheButton);
+        Context context = getContext().getApplicationContext();
+        View.OnClickListener purgeCacheOnClickListener = new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                boolean status = tvCastingApp.purgeCache();
+                Toast.makeText(context, "Cache purge " + (status ? "successful!" : "failed!"), Toast.LENGTH_SHORT).show();
+            }
+        };
+        purgeCacheButton.setOnClickListener(purgeCacheOnClickListener);
+
         ArrayAdapter<DiscoveredNodeData> arrayAdapter = new VideoPlayerCommissionerAdapter(getActivity(), commissionerVideoPlayerList);
         final ListView list = getActivity().findViewById(R.id.commissionerList);
         list.setAdapter(arrayAdapter);

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CommissionerDiscoveryFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CommissionerDiscoveryFragment.java
@@ -83,7 +83,6 @@ public class CommissionerDiscoveryFragment extends Fragment {
             v -> callback.handleCommissioningButtonClicked(null);
         manualCommissioningButton.setOnClickListener(manualCommissioningButtonOnClickListener);
 
-
         Button purgeCacheButton = getView().findViewById(R.id.purgeCacheButton);
         Context context = getContext().getApplicationContext();
         View.OnClickListener purgeCacheOnClickListener = new View.OnClickListener() {

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
@@ -183,6 +183,8 @@ public class TvCastingApp {
 
   public native List<VideoPlayer> getActiveTargetVideoPlayers();
 
+  public native boolean purgeCache();
+
   /*
    * CONTENT LAUNCHER CLUSTER
    *

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
@@ -306,6 +306,20 @@ exit:
     return true;
 }
 
+JNI_METHOD(jboolean, purgeCache)(JNIEnv * env, jobject)
+{
+    chip::DeviceLayer::StackLock lock;
+    ChipLogProgress(AppServer, "JNI_METHOD purgeCache called");
+
+    CHIP_ERROR err = CastingServer::GetInstance()->PurgeCache();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(AppServer, "TVCastingApp-JNI::purgeCache failed: %" CHIP_ERROR_FORMAT, err.Format());
+        return false;
+    }
+    return true;
+}
+
 JNI_METHOD(jboolean, contentLauncherLaunchURL)
 (JNIEnv * env, jobject, jobject contentApp, jstring contentUrl, jstring contentDisplayStr, jobject jResponseHandler)
 {

--- a/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_commissioner_discovery.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_commissioner_discovery.xml
@@ -15,6 +15,12 @@
         android:padding="10sp">
 
         <Button
+            android:id="@+id/purgeCacheButton"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:text="Purge Cache" />
+
+        <Button
             android:id="@+id/manualCommissioningButton"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.h
@@ -191,9 +191,9 @@
 
  @param clientQueue Queue to invoke callbacks on
 
- @param requestSentHandler Called after the request has been sent
+ @param responseHandler Called when purgeCache completes
  */
-- (void)purgeCache:(dispatch_queue_t _Nonnull)clientQueue requestSentHandler:(nullable void (^)())requestSentHandler;
+- (void)purgeCache:(dispatch_queue_t _Nonnull)clientQueue responseHandler:(nullable void (^)(MatterError * _Nonnull))responseHandler;
 
 /**
  @brief Start the Matter server and reconnect to a previously connected Video Player (if any). This API is async

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.h
@@ -193,7 +193,7 @@
 
  @param responseHandler Called when purgeCache completes
  */
-- (void)purgeCache:(dispatch_queue_t _Nonnull)clientQueue responseHandler:(nullable void (^)(MatterError * _Nonnull))responseHandler;
+- (void)purgeCache:(dispatch_queue_t _Nonnull)clientQueue responseHandler:(void (^)(MatterError * _Nonnull))responseHandler;
 
 /*!
  @brief Start the Matter server and reconnect to a previously connected Video Player (if any). This API is async

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.h
@@ -186,6 +186,15 @@
  */
 - (void)disconnect:(dispatch_queue_t _Nonnull)clientQueue requestSentHandler:(nullable void (^)())requestSentHandler;
 
+/*!
+ @brief Purge data cached by the Matter casting library
+
+ @param clientQueue Queue to invoke callbacks on
+
+ @param requestSentHandler Called after the request has been sent
+ */
+- (void)purgeCache:(dispatch_queue_t _Nonnull)clientQueue requestSentHandler:(nullable void (^)())requestSentHandler;
+
 /**
  @brief Start the Matter server and reconnect to a previously connected Video Player (if any). This API is async
 

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.h
@@ -195,7 +195,7 @@
  */
 - (void)purgeCache:(dispatch_queue_t _Nonnull)clientQueue responseHandler:(nullable void (^)(MatterError * _Nonnull))responseHandler;
 
-/**
+/*!
  @brief Start the Matter server and reconnect to a previously connected Video Player (if any). This API is async
 
  @param clientQueue Queue to invoke callbacks on

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
@@ -833,13 +833,12 @@
 
 - (void)purgeCache:(dispatch_queue_t _Nonnull)clientQueue responseHandler:(nullable void (^)(MatterError * _Nonnull))responseHandler
 {
-    ChipLogProgress(AppServer, "CastingServerBridge().purgeCache() called");
-    dispatch_async(_chipWorkQueue, ^{
+    [self dispatchOnMatterSDKQueue:@"purgeCache(...)" block:^{
         CHIP_ERROR err = CastingServer::GetInstance()->PurgeCache();
         dispatch_async(clientQueue, ^{
             responseHandler([[MatterError alloc] initWithCode:err.AsInteger() message:[NSString stringWithUTF8String:err.AsString()]]);
         });
-    });
+    }];
 }
 
 - (void)contentLauncher_launchUrl:(ContentApp * _Nonnull)contentApp

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
@@ -831,13 +831,13 @@
     }];
 }
 
-- (void)purgeCache:(dispatch_queue_t _Nonnull)clientQueue requestSentHandler:(nullable void (^)())requestSentHandler
+- (void)purgeCache:(dispatch_queue_t _Nonnull)clientQueue responseHandler:(nullable void (^)(MatterError * _Nonnull))responseHandler
 {
     ChipLogProgress(AppServer, "CastingServerBridge().purgeCache() called");
     dispatch_async(_chipWorkQueue, ^{
-        CastingServer::GetInstance()->PurgeCache();
+        CHIP_ERROR err = CastingServer::GetInstance()->PurgeCache();
         dispatch_async(clientQueue, ^{
-            requestSentHandler();
+            responseHandler([[MatterError alloc] initWithCode:err.AsInteger() message:[NSString stringWithUTF8String:err.AsString()]]);
         });
     });
 }

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
@@ -831,7 +831,7 @@
     }];
 }
 
-- (void)purgeCache:(dispatch_queue_t _Nonnull)clientQueue responseHandler:(nullable void (^)(MatterError * _Nonnull))responseHandler
+- (void)purgeCache:(dispatch_queue_t _Nonnull)clientQueue responseHandler:(void (^)(MatterError * _Nonnull))responseHandler
 {
     [self dispatchOnMatterSDKQueue:@"purgeCache(...)" block:^{
         CHIP_ERROR err = CastingServer::GetInstance()->PurgeCache();

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
@@ -831,6 +831,17 @@
     }];
 }
 
+- (void)purgeCache:(dispatch_queue_t _Nonnull)clientQueue requestSentHandler:(nullable void (^)())requestSentHandler
+{
+    ChipLogProgress(AppServer, "CastingServerBridge().purgeCache() called");
+    dispatch_async(_chipWorkQueue, ^{
+        CastingServer::GetInstance()->PurgeCache();
+        dispatch_async(clientQueue, ^{
+            requestSentHandler();
+        });
+    });
+}
+
 - (void)contentLauncher_launchUrl:(ContentApp * _Nonnull)contentApp
                        contentUrl:(NSString * _Nonnull)contentUrl
                 contentDisplayStr:(NSString * _Nonnull)contentDisplayStr

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/StartFromCacheView.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/StartFromCacheView.swift
@@ -28,6 +28,15 @@ struct StartFromCacheView: View {
     
     var body: some View {
         VStack(alignment: .leading) {
+            Button("Purge cache", action: {
+                viewModel.purgeAndReReadCache()
+            })
+            .frame(width: 200, height: 30, alignment: .center)
+            .border(Color.black, width: 1)
+            .background(Color.blue)
+            .foregroundColor(Color.white)
+            .padding()
+            
             NavigationLink(
                 destination: CommissionerDiscoveryView(),
                 label: {

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/StartFromCacheViewModel.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/StartFromCacheViewModel.swift
@@ -35,4 +35,16 @@ class StartFromCacheViewModel: ObservableObject {
             })
         }
     }
+    
+    func purgeAndReReadCache() {
+        if let castingServerBridge = CastingServerBridge.getSharedInstance()
+        {
+            castingServerBridge.purgeCache(DispatchQueue.main, responseHandler: { (error: MatterError) -> () in
+                DispatchQueue.main.async {
+                    self.Log.info("purgeCache returned \(error)")
+                    self.readFromCache()
+                }
+            })
+        }
+    }
 }

--- a/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
@@ -99,7 +99,7 @@ public:
                                            std::function<void(TargetEndpointInfo *)> onNewOrUpdatedEndpoint);
 
     void LogCachedVideoPlayers();
-    CHIP_ERROR PurgeVideoPlayerCache();
+    CHIP_ERROR PurgeCache();
 
     /**
      * Tears down all active subscriptions.

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -352,7 +352,7 @@ CHIP_ERROR CastingServer::VerifyOrEstablishConnection(TargetVideoPlayerInfo & ta
         onConnectionFailure);
 }
 
-CHIP_ERROR CastingServer::PurgeVideoPlayerCache()
+CHIP_ERROR CastingServer::PurgeCache()
 {
     return mPersistenceManager.PurgeVideoPlayerCache();
 }

--- a/examples/tv-casting-app/tv-casting-common/src/PersistenceManager.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/PersistenceManager.cpp
@@ -443,5 +443,11 @@ void PersistenceManager::OnFabricRemoved(const FabricTable & fabricTable, Fabric
 CHIP_ERROR PersistenceManager::PurgeVideoPlayerCache()
 {
     ChipLogProgress(AppServer, "PersistenceManager::PurgeVideoPlayerCache called");
-    return chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr().Delete(kCastingDataKey);
+    CHIP_ERROR err = chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr().Delete(kCastingDataKey);
+    if(err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND) // no error, if the key-value pair was not stored
+    {
+        ChipLogProgress(AppServer, "PersistenceManager::PurgeVideoPlayerCache ignoring error %" CHIP_ERROR_FORMAT, err.Format());
+        return CHIP_NO_ERROR;
+    }
+    return err;
 }


### PR DESCRIPTION
### Problem
A client app may want to have an ability to clear the list of video players previously connected to, say in the case a user signs out and a different user has to sign in. The Matter Tv Casting library should expose a way to purge the cache

### Change summary
1. Exposed APIs in the libraries for Android, iOS and common to PurgeCache
2. Added buttons to the Android and iOS tv-casting-app to Purge the cache.

### Testing
Tested using the Android / iOS tv-casting-apps running against a Linux tv-app