### PR TITLE
Safely dispose of resources on Server Shutdown

### DIFF
--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -61,7 +61,7 @@ public:
     }
 
     CHIP_ERROR Init(chip::System::Layer * systemLayer, const CASESessionManagerConfig & params);
-    void Shutdown() {}
+    void Shutdown() { ReleaseAllSessions(); }
 
     /**
      * Find an existing session for the given node ID, or trigger a new session


### PR DESCRIPTION
Fixes the root cause of #25023

[Problem]

The Server::Shutdown API releases resources in the reverse order in which they were allocated. Unfortunately, there is a cyclic dependency between the ExchangeMgr, which is released first, and the SessionManager, which contains one or more Sessions that may need to release ExchangeContexts. If an ExchangeContext is awaiting a response when it is aborted, it uses the (now-null) ExchangeMgr for cleanup, resulting in a segmentation fault.

[Solution]

Shut down the SessionManager before the ExchangeMgr. While counter-intuitive and somewhat of an anti-pattern, this ensures that the necessary resources are available for the SessionManager to shut down. The ExchangeMgr shutdown process has relatively few side effects and is currently safe to defer.

[Problem]

The Server::Shutdown API shuts down the CASESessionManager, but the CASESessionManager's Shutdown API is a no-op. This leaves pending CASE sessions still being established alive after the CASESessionManager, SessionManager, and ExchangeMgr have all been shut down and eventually causes a segmentation fault.

[Solution]

Release all pending CASE sessions on shutdown. This makes sense as there isn't anything to do with the sessions when everything else has been shut down.