### PR TITLE
Default to use an IPV4 address

### DIFF
--- a/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
@@ -430,7 +430,7 @@ private:
     /**
      * @brief Retrieve the IP Address to use for the UDC request.
      * This function will look for an IPv4 address in the list of IPAddresses passed in if available and return
-     * that address if found. If there are no available IPv4 addresses, it will default to the first avaialble address.
+     * that address if found. If there are no available IPv4 addresses, it will default to the first available address.
      * This logic is similar to the one used by the UDC server that prefers IPv4 addresses.
      *
      * @param ipAddresses - The list of ip addresses available to use

--- a/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
@@ -427,6 +427,19 @@ private:
     static void DeviceEventCallback(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
     void ReadServerClusters(chip::EndpointId endpointId);
 
+    /**
+     * @brief Retrieve the IP Address to use for the UDC request.
+     * This function will look for an IPv4 address in the list of IPAddresses passed in if available and return
+     * that address if found. If there are no available IPv4 addresses, it will default to the first avaialble address.
+     * This logic is similar to the one used by the UDC server that prefers IPv4 addresses.
+     *
+     * @param ipAddresses - The list of ip addresses available to use
+     * @param numIPs - The number of ip addresses available in the array
+     *
+     * @returns The IPv4 address in the array if available, otherwise will return the first address in the list.
+     */
+    static chip::Inet::IPAddress *getIpAddressForUDCRequest(chip::Inet::IPAddress ipAddresses[], const int numIPs);
+
     PersistenceManager mPersistenceManager;
     bool mInited        = false;
     bool mUdcInProgress = false;


### PR DESCRIPTION
On some devices it appears that the commissioner may not have an appropriate IPV6 address and attempts to send a user directed commissioning request to a device using its IPV6 address.

Its a bit unclear how this situation happens but in theory it could occur. In most cases this should be safe to default to an ipv4 address if it is available.

The implementation of the user directed commissioning server does something similar.
