### PR TITLE
Fixing a few build issues

### DIFF
--- a/examples/tv-app/tv-common/include/CHIPProjectAppConfig.h
+++ b/examples/tv-app/tv-common/include/CHIPProjectAppConfig.h
@@ -30,6 +30,8 @@
 // TVs need to be commissioners and likely want to be discoverable
 #define CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY 1
 
+#define CHIP_DEVICE_CONFIG_MAX_DISCOVERED_IP_ADDRESSES 10
+
 // TVs need to be both commissioners and commissionees
 #define CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE 1
 

--- a/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
@@ -450,7 +450,7 @@ private:
     uint16_t mTargetVideoPlayerDeviceType                                 = 0;
     char mTargetVideoPlayerDeviceName[chip::Dnssd::kMaxDeviceNameLen + 1] = {};
     char mTargetVideoPlayerHostName[chip::Dnssd::kHostNameMaxLength + 1]  = {};
-    size_t mTargetVideoPlayerNumIPs                                       = 0; // number of valid IP addresses
+    uint8_t mTargetVideoPlayerNumIPs                                      = 0; // number of valid IP addresses
     chip::Inet::IPAddress mTargetVideoPlayerIpAddress[chip::Dnssd::CommonResolutionData::kMaxIPAddresses];
 
     chip::Controller::CommissionableNodeController mCommissionableNodeController;

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -187,15 +187,15 @@ CHIP_ERROR CastingServer::SendUserDirectedCommissioningRequest(Dnssd::Discovered
     mUdcInProgress = true;
     // Send User Directed commissioning request
     chip::Inet::IPAddress *ipAddressToUse = getIpAddressForUDCRequest(selectedCommissioner->resolutionData.ipAddress,
-        selectedCommissioner->resolutionData.numIPs);
+        (uint8_t)selectedCommissioner->resolutionData.numIPs);
     ReturnErrorOnFailure(SendUserDirectedCommissioningRequest(chip::Transport::PeerAddress::UDP(
         *ipAddressToUse, selectedCommissioner->resolutionData.port,
         selectedCommissioner->resolutionData.interfaceId)));
     mTargetVideoPlayerVendorId   = selectedCommissioner->commissionData.vendorId;
     mTargetVideoPlayerProductId  = selectedCommissioner->commissionData.productId;
     mTargetVideoPlayerDeviceType = selectedCommissioner->commissionData.deviceType;
-    mTargetVideoPlayerNumIPs     = selectedCommissioner->resolutionData.numIPs;
-    for (size_t i = 0; i < mTargetVideoPlayerNumIPs && i < chip::Dnssd::CommonResolutionData::kMaxIPAddresses; i++)
+    mTargetVideoPlayerNumIPs     = (uint8_t)selectedCommissioner->resolutionData.numIPs;
+    for (uint8_t i = 0; i < mTargetVideoPlayerNumIPs && i < chip::Dnssd::CommonResolutionData::kMaxIPAddresses; i++)
     {
         mTargetVideoPlayerIpAddress[i] = selectedCommissioner->resolutionData.ipAddress[i];
     }


### PR DESCRIPTION
I saw a couple build issues when trying to build the tv casting app.

```
implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') ...
```

This does some casting to fix it. Shouldn't be a problem since num ips should always be small.

Also saw an issue with building the tv-app since the `CHIP_DEVICE_CONFIG_MAX_DISCOVERED_IP_ADDRESSES` was undefined

