### PR TITLE
Reverting to using size_t for numIPs

### DIFF
--- a/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
@@ -438,7 +438,7 @@ private:
      *
      * @returns The IPv4 address in the array if available, otherwise will return the first address in the list.
      */
-    static chip::Inet::IPAddress *getIpAddressForUDCRequest(chip::Inet::IPAddress ipAddresses[], const int numIPs);
+    static chip::Inet::IPAddress *getIpAddressForUDCRequest(chip::Inet::IPAddress ipAddresses[], const size_t numIPs);
 
     PersistenceManager mPersistenceManager;
     bool mInited        = false;
@@ -450,7 +450,7 @@ private:
     uint16_t mTargetVideoPlayerDeviceType                                 = 0;
     char mTargetVideoPlayerDeviceName[chip::Dnssd::kMaxDeviceNameLen + 1] = {};
     char mTargetVideoPlayerHostName[chip::Dnssd::kHostNameMaxLength + 1]  = {};
-    uint8_t mTargetVideoPlayerNumIPs                                      = 0; // number of valid IP addresses
+    size_t mTargetVideoPlayerNumIPs                                      = 0; // number of valid IP addresses
     chip::Inet::IPAddress mTargetVideoPlayerIpAddress[chip::Dnssd::CommonResolutionData::kMaxIPAddresses];
 
     chip::Controller::CommissionableNodeController mCommissionableNodeController;

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -160,15 +160,15 @@ CHIP_ERROR CastingServer::SendUserDirectedCommissioningRequest(chip::Transport::
     return Server::GetInstance().SendUserDirectedCommissioningRequest(commissioner);
 }
 
-chip::Inet::IPAddress *CastingServer::getIpAddressForUDCRequest(chip::Inet::IPAddress ipAddresses[], const int numIPs)
+chip::Inet::IPAddress *CastingServer::getIpAddressForUDCRequest(chip::Inet::IPAddress ipAddresses[], const size_t numIPs)
 {
-    int ipIndexToUse = 0;
-    for (int i = 0; i < numIPs; i++)
+    size_t ipIndexToUse = 0;
+    for (size_t i = 0; i < numIPs; i++)
     {
         if (ipAddresses[i].IsIPv4())
         {
             ipIndexToUse = i;
-            ChipLogProgress(AppServer, "Found iPv4 address at index: %d", ipIndexToUse);
+            ChipLogProgress(AppServer, "Found iPv4 address at index: %lu", ipIndexToUse);
             break;
         }
 


### PR DESCRIPTION
### Change summary

numIPs in Resolver.h: https://github.com/project-chip/connectedhomeip/blob/master/src/lib/dnssd/Resolver.h#L46 is defined as a size_t. It'd be easier going forward if similar data members in the tv-casting app code use the same data type (like mTargetVideoPlayerNumIPs) - hence this change.

### Testing
Built and Tested with the Android tv-casting-app