### PR TITLE
Use TargetServiceInfo to resolve the ServiceType

### DIFF
--- a/src/platform/android/java/chip/platform/NsdServiceFinderAndResolver.java
+++ b/src/platform/android/java/chip/platform/NsdServiceFinderAndResolver.java
@@ -132,7 +132,10 @@ class NsdServiceFinderAndResolver implements NsdManager.DiscoveryListener {
                 "Failed to resolve service '" + serviceInfo.getServiceName() + "': " + errorCode);
             chipMdnsCallback.handleServiceResolve(
                 serviceInfo.getServiceName(),
-                serviceInfo.getServiceType(),
+                // Use the target service info since the resolved service info sometimes appends a "." at the front
+                // likely because it is trying to strip the service name out of it and something is missed.
+                // The target service info service type should be effectively the same as the resolved service info.
+                NsdServiceFinderAndResolver.this.targetServiceInfo.getServiceType(),
                 null,
                 null,
                 0,
@@ -156,12 +159,17 @@ class NsdServiceFinderAndResolver implements NsdManager.DiscoveryListener {
                 TAG,
                 "Resolved service '"
                     + serviceInfo.getServiceName()
-                    + "' to "
+                    + "' ("
+                    + serviceInfo.getServiceType()
+                    + ") to "
                     + serviceInfo.getHost());
             // TODO: Find out if DNS-SD results for Android should contain interface ID
             chipMdnsCallback.handleServiceResolve(
                 serviceInfo.getServiceName(),
-                serviceInfo.getServiceType(),
+                // Use the target service info since the resolved service info sometimes appends a "." at the front
+                // likely because it is trying to strip the service name out of it and something is missed.
+                // The target service info service type should be effectively the same as the resolved service info.
+                NsdServiceFinderAndResolver.this.targetServiceInfo.getServiceType(),
                 serviceInfo.getHost().getHostName(),
                 serviceInfo.getHost().getHostAddress(),
                 serviceInfo.getPort(),


### PR DESCRIPTION
On my network, the service type resolved with an extra `.` at the front (`._matterc._udp`) even though the requested service type was `_matterc._udp`. This is impactful because internally we do a check for the length of the service type and it has to match the max length (13). In this case because of the extra "." the check fails.

I've changed this to just use the ServiceInfo we used to start the resolution with so that there is no contention here.

With this change I was able to successfully commission, without it, commissioning failed.