### PR TITLE
Android tv-casting-app: Allowing RE-setting DACProvider

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
@@ -108,11 +108,8 @@ JNI_METHOD(void, setDACProvider)(JNIEnv *, jobject, jobject provider)
     chip::DeviceLayer::StackLock lock;
     ChipLogProgress(AppServer, "JNI_METHOD setDACProvider called");
 
-    if (!chip::Credentials::IsDeviceAttestationCredentialsProviderSet())
-    {
-        JNIDACProvider * p = new JNIDACProvider(provider);
-        chip::Credentials::SetDeviceAttestationCredentialsProvider(p);
-    }
+    JNIDACProvider * p = new JNIDACProvider(provider);
+    chip::Credentials::SetDeviceAttestationCredentialsProvider(p);
 }
 
 JNI_METHOD(jboolean, openBasicCommissioningWindow)

--- a/examples/tv-casting-app/android/args.gni
+++ b/examples/tv-casting-app/android/args.gni
@@ -26,9 +26,6 @@ chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
 
 chip_build_libshell = true
 
-# Example Credentials like ExampleDAC.h/cpp are not required for the tv-casting-app
-chip_build_example_creds = false
-
 chip_enable_additional_data_advertising = true
 
 chip_enable_rotating_device_id = true


### PR DESCRIPTION
## Change summary

The AndroidAppServerWrapper in the core SDK defaults to setting the ExampleDACProvider per https://github.com/project-chip/connectedhomeip/blob/master/src/app/server/java/AndroidAppServerWrapper.cpp#L59-L62

In this change, we allow the Android tv-casting app setDACProvider  API to reset the DAC Provider. Also, since the AndroidAppServerWrapper requires the ExampleDACProvider, we need to allow building of the example credentials (that is let chip_build_example_creds default to true)