### PR TITLE
Including ExampleDACs for linux/tv-casting-app

### DIFF
--- a/examples/tv-casting-app/linux/args.gni
+++ b/examples/tv-casting-app/linux/args.gni
@@ -26,9 +26,6 @@ chip_project_config_include_dirs += [ "${chip_root}/config/standalone" ]
 
 chip_build_libshell = true
 
-# Example Credentials like ExampleDAC.h/cpp are not required for the tv-casting-app
-chip_build_example_creds = false
-
 chip_enable_additional_data_advertising = true
 
 chip_enable_rotating_device_id = true


### PR DESCRIPTION
### Change summary
This change defaults to leaving chip_build_example_creds set to true because the linux tv-casting-app uses the Example DAC classes: https://github.com/sharadb-amazon/connectedhomeip/blob/master/examples/tv-casting-app/linux/main.cpp#L128
Without this, the build was failing with the following error: 

```
2023-03-14 13:07:31 INFO    /__w/connectedhomeip/connectedhomeip/out/linux-x64-tv-casting-app/../../examples/tv-casting-app/linux/third_party/connectedhomeip/examples/chip-tool/commands/example/ExampleCredentialIssuerCommands.h:38: undefined reference to `chip::Credentials::Examples::GetExampleDACProvider()'
2023-03-14 13:07:31 INFO    /usr/bin/ld: obj/chip-tv-casting-app.main.cpp.o: in function `main':
2023-03-14 13:07:31 INFO    /__w/connectedhomeip/connectedhomeip/out/linux-x64-tv-casting-app/../../examples/tv-casting-app/linux/main.cpp:128: undefined reference to `chip::Credentials::Examples::GetExampleDACProvider()'
2023-03-14 13:07:31 INFO    /usr/bin/ld: obj/third_party/connectedhomeip/examples/platform/linux/app-main.Options.cpp.o: in function `LinuxDeviceOptions::GetInstance()':
2023-03-14 13:07:31 INFO    /__w/connectedhomeip/connectedhomeip/out/linux-x64-tv-casting-app/../../examples/tv-casting-app/linux/third_party/connectedhomeip/examples/platform/linux/Options.cpp:515: undefined reference to `chip::Credentials::Examples::GetExampleDACProvider()'
```

### Testing
Built the Linux tv-casting-app successfully