### PR TITLE
tv-casting-app zap: Updated FeatureMap value in NetworkCommissioning cluster from 5 to 1 (WIFI)

### DIFF
--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -1734,7 +1734,7 @@ endpoint 0 {
     ram      attribute lastNetworkingStatus;
     ram      attribute lastNetworkID;
     ram      attribute lastConnectErrorValue;
-    ram      attribute featureMap default = 5;
+    ram      attribute featureMap default = 1;
     ram      attribute clusterRevision default = 1;
   }
 

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.zap
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.zap
@@ -2274,7 +2274,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "5",
+              "defaultValue": "1",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/zzz_generated/tv-casting-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/tv-casting-app/zap-generated/endpoint_config.h
@@ -219,7 +219,7 @@
             { 0x00000005, ZAP_TYPE(ENUM8), 1, ZAP_ATTRIBUTE_MASK(NULLABLE), ZAP_EMPTY_DEFAULT() },   /* LastNetworkingStatus */    \
             { 0x00000006, ZAP_TYPE(OCTET_STRING), 33, ZAP_ATTRIBUTE_MASK(NULLABLE), ZAP_EMPTY_DEFAULT() }, /* LastNetworkID */     \
             { 0x00000007, ZAP_TYPE(INT32S), 4, ZAP_ATTRIBUTE_MASK(NULLABLE), ZAP_EMPTY_DEFAULT() }, /* LastConnectErrorValue */    \
-            { 0x0000FFFC, ZAP_TYPE(BITMAP32), 4, 0, ZAP_SIMPLE_DEFAULT(5) },                        /* FeatureMap */               \
+            { 0x0000FFFC, ZAP_TYPE(BITMAP32), 4, 0, ZAP_SIMPLE_DEFAULT(1) },                        /* FeatureMap */               \
             { 0x0000FFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(1) },                          /* ClusterRevision */          \
                                                                                                                                    \
             /* Endpoint: 0, Cluster: General Diagnostics (server) */                                                               \


### PR DESCRIPTION
### Change summary
FeatureMap attribute on the NetworkCommissioning was set to 5. That value is invalid. As per the Matter spec:

> There SHALL be exactly one of the features bits in the set (WI, TH, ET) present in teh FeatureMap attribute, to describe the type of network technology supported by a given instance of this cluster.

This PR sets it to 1 for WIFI.

### Testing
Tested using the Android/iOS tv-casting-app that commissioning, commands and subscriptions work when working with the Linux tv-app.