### PR TITLE
Making TvCastingApp singleton and synchronizing discovery code

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MainActivity.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MainActivity.java
@@ -76,7 +76,7 @@ public class MainActivity extends AppCompatActivity
    * TvCastingApp
    */
   private boolean initJni() {
-    tvCastingApp = new TvCastingApp();
+    tvCastingApp = TvCastingApp.getInstance();
 
     tvCastingApp.setDACProvider(new DACProviderStub());
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
@@ -32,13 +32,13 @@ import chip.platform.PreferencesKeyValueStoreManager;
 import java.util.Arrays;
 import java.util.List;
 
-public final class TvCastingApp {
+public class TvCastingApp {
   private static final String TAG = TvCastingApp.class.getSimpleName();
   private static final String DISCOVERY_TARGET_SERVICE_TYPE = "_matterd._udp.";
   private static final List<Long> DISCOVERY_TARGET_DEVICE_TYPE_FILTER =
       Arrays.asList(35L); // Video player = 35;
 
-  private static TvCastingApp _instance;
+  private static TvCastingApp sInstance;
   private Context applicationContext;
   private ChipAppServer chipAppServer;
   private NsdManagerServiceResolver.NsdManagerResolverAvailState nsdManagerResolverAvailState;
@@ -52,10 +52,10 @@ public final class TvCastingApp {
   private TvCastingApp() {}
 
   public static TvCastingApp getInstance() {
-    if (_instance == null) {
-      _instance = new TvCastingApp();
+    if (sInstance == null) {
+      sInstance = new TvCastingApp();
     }
-    return _instance;
+    return sInstance;
   }
 
   public boolean initApp(Context applicationContext, AppParameters appParameters) {
@@ -165,7 +165,7 @@ public final class TvCastingApp {
         try {
           nsdManager.stopServiceDiscovery(nsdDiscoveryListener);
         } catch (IllegalArgumentException e) {
-          Log.e(
+          Log.w(
               TAG,
               "TvCastingApp received exception on calling nsdManager.stopServiceDiscovery() "
                   + e.getMessage());

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
@@ -32,20 +32,31 @@ import chip.platform.PreferencesKeyValueStoreManager;
 import java.util.Arrays;
 import java.util.List;
 
-public class TvCastingApp {
+public final class TvCastingApp {
   private static final String TAG = TvCastingApp.class.getSimpleName();
   private static final String DISCOVERY_TARGET_SERVICE_TYPE = "_matterd._udp.";
   private static final List<Long> DISCOVERY_TARGET_DEVICE_TYPE_FILTER =
       Arrays.asList(35L); // Video player = 35;
 
+  private static TvCastingApp _instance;
   private Context applicationContext;
   private ChipAppServer chipAppServer;
   private NsdManagerServiceResolver.NsdManagerResolverAvailState nsdManagerResolverAvailState;
   private boolean discoveryStarted = false;
+  private Object discoveryLock = new Object();
 
   private WifiManager.MulticastLock multicastLock;
   private NsdManager nsdManager;
   private NsdDiscoveryListener nsdDiscoveryListener;
+
+  private TvCastingApp() {}
+
+  public static TvCastingApp getInstance() {
+    if (_instance == null) {
+      _instance = new TvCastingApp();
+    }
+    return _instance;
+  }
 
   public boolean initApp(Context applicationContext, AppParameters appParameters) {
     if (applicationContext == null
@@ -109,50 +120,62 @@ public class TvCastingApp {
   public void discoverVideoPlayerCommissioners(
       SuccessCallback<DiscoveredNodeData> discoverySuccessCallback,
       FailureCallback discoveryFailureCallback) {
-    Log.d(TAG, "TvCastingApp.discoverVideoPlayerCommissioners called");
+    synchronized (discoveryLock) {
+      Log.d(TAG, "TvCastingApp.discoverVideoPlayerCommissioners called");
 
-    if (this.discoveryStarted) {
-      Log.d(TAG, "Discovery already started, stopping before starting again");
-      stopVideoPlayerDiscovery();
+      if (this.discoveryStarted) {
+        Log.d(TAG, "Discovery already started, stopping before starting again");
+        stopVideoPlayerDiscovery();
+      }
+
+      List<VideoPlayer> preCommissionedVideoPlayers = readCachedVideoPlayers();
+
+      WifiManager wifiManager =
+          (WifiManager) applicationContext.getSystemService(Context.WIFI_SERVICE);
+      multicastLock = wifiManager.createMulticastLock("multicastLock");
+      multicastLock.setReferenceCounted(true);
+      multicastLock.acquire();
+
+      nsdManager = (NsdManager) applicationContext.getSystemService(Context.NSD_SERVICE);
+      nsdDiscoveryListener =
+          new NsdDiscoveryListener(
+              nsdManager,
+              DISCOVERY_TARGET_SERVICE_TYPE,
+              DISCOVERY_TARGET_DEVICE_TYPE_FILTER,
+              preCommissionedVideoPlayers,
+              discoverySuccessCallback,
+              discoveryFailureCallback,
+              nsdManagerResolverAvailState);
+
+      nsdManager.discoverServices(
+          DISCOVERY_TARGET_SERVICE_TYPE, NsdManager.PROTOCOL_DNS_SD, nsdDiscoveryListener);
+      Log.d(TAG, "TvCastingApp.discoverVideoPlayerCommissioners started");
+      this.discoveryStarted = true;
     }
-
-    List<VideoPlayer> preCommissionedVideoPlayers = readCachedVideoPlayers();
-
-    WifiManager wifiManager =
-        (WifiManager) applicationContext.getSystemService(Context.WIFI_SERVICE);
-    multicastLock = wifiManager.createMulticastLock("multicastLock");
-    multicastLock.setReferenceCounted(true);
-    multicastLock.acquire();
-
-    nsdManager = (NsdManager) applicationContext.getSystemService(Context.NSD_SERVICE);
-    nsdDiscoveryListener =
-        new NsdDiscoveryListener(
-            nsdManager,
-            DISCOVERY_TARGET_SERVICE_TYPE,
-            DISCOVERY_TARGET_DEVICE_TYPE_FILTER,
-            preCommissionedVideoPlayers,
-            discoverySuccessCallback,
-            discoveryFailureCallback,
-            nsdManagerResolverAvailState);
-
-    nsdManager.discoverServices(
-        DISCOVERY_TARGET_SERVICE_TYPE, NsdManager.PROTOCOL_DNS_SD, nsdDiscoveryListener);
-    Log.d(TAG, "TvCastingApp.discoverVideoPlayerCommissioners started");
-    this.discoveryStarted = true;
   }
 
   public void stopVideoPlayerDiscovery() {
-    Log.d(TAG, "TvCastingApp trying to stop video player discovery");
-    if (this.discoveryStarted
-        && nsdManager != null
-        && multicastLock != null
-        && nsdDiscoveryListener != null) {
-      Log.d(TAG, "TvCastingApp stopping Video Player commissioner discovery");
-      nsdManager.stopServiceDiscovery(nsdDiscoveryListener);
-      if (multicastLock.isHeld()) {
-        multicastLock.release();
+    synchronized (discoveryLock) {
+      Log.d(TAG, "TvCastingApp trying to stop video player discovery");
+      if (this.discoveryStarted
+          && nsdManager != null
+          && multicastLock != null
+          && nsdDiscoveryListener != null) {
+        Log.d(TAG, "TvCastingApp stopping Video Player commissioner discovery");
+        try {
+          nsdManager.stopServiceDiscovery(nsdDiscoveryListener);
+        } catch (IllegalArgumentException e) {
+          Log.e(
+              TAG,
+              "TvCastingApp received exception on calling nsdManager.stopServiceDiscovery() "
+                  + e.getMessage());
+        }
+
+        if (multicastLock.isHeld()) {
+          multicastLock.release();
+        }
+        this.discoveryStarted = false;
       }
-      this.discoveryStarted = false;
     }
   }
 


### PR DESCRIPTION
### Problem
Two or more instances of the TvCastingApp could be initialized by client code,  that would end up sharing the same resources like the NsdManager or TvCastingApp-JNI, which could cause inconsistencies.
We are not synchronizing the execution of the discovery related code in discoverVideoPlayerCommissioners or stopVideoPlayerDiscovery which can lead to errors. Like the crash "listener not registered" if stopVideoPlayerDiscovery is called a second time before its first execution finishes.

### Change summary
* Made the TvCastingApp a singleton
* Synchronized discoverVideoPlayerCommissioners() and stopVideoPlayerDiscovery()
* Logged an error if we get an IllegalArgumentException (for  "listener not registered") on calling nsdManager.stopDiscovery()

### Testing
Tested with the Android tv-casting-app and ensured discovery works.