### PR TITLE
Android/tv-casting-app: Fix for issue in finding handleInternal() on some Android phones

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/FailureCallback.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/FailureCallback.java
@@ -24,7 +24,7 @@ public abstract class FailureCallback {
 
   public abstract void handle(MatterError err);
 
-  private final void handleInternal(int errorCode, String errorMessage) {
+  protected final void handleInternal(int errorCode, String errorMessage) {
     try {
       handle(new MatterError(errorCode, errorMessage));
     } catch (Throwable t) {

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/FailureCallback.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/FailureCallback.java
@@ -24,7 +24,7 @@ public abstract class FailureCallback {
 
   public abstract void handle(MatterError err);
 
-  public final void handleInternal(int errorCode, String errorMessage) {
+  private final void handleInternal(int errorCode, String errorMessage) {
     try {
       handle(new MatterError(errorCode, errorMessage));
     } catch (Throwable t) {

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/FailureCallback.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/FailureCallback.java
@@ -24,7 +24,7 @@ public abstract class FailureCallback {
 
   public abstract void handle(MatterError err);
 
-  private final void handleInternal(int errorCode, String errorMessage) {
+  public final void handleInternal(int errorCode, String errorMessage) {
     try {
       handle(new MatterError(errorCode, errorMessage));
     } catch (Throwable t) {

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/MatterCallbackHandler.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/MatterCallbackHandler.java
@@ -24,7 +24,7 @@ public abstract class MatterCallbackHandler {
 
   public abstract void handle(MatterError err);
 
-  private final void handleInternal(int errorCode, String errorMessage) {
+  protected final void handleInternal(int errorCode, String errorMessage) {
     try {
       handle(new MatterError(errorCode, errorMessage));
     } catch (Throwable t) {

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/MatterCallbackHandler.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/MatterCallbackHandler.java
@@ -24,7 +24,7 @@ public abstract class MatterCallbackHandler {
 
   public abstract void handle(MatterError err);
 
-  public final void handleInternal(int errorCode, String errorMessage) {
+  private final void handleInternal(int errorCode, String errorMessage) {
     try {
       handle(new MatterError(errorCode, errorMessage));
     } catch (Throwable t) {

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/MatterCallbackHandler.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/MatterCallbackHandler.java
@@ -24,7 +24,7 @@ public abstract class MatterCallbackHandler {
 
   public abstract void handle(MatterError err);
 
-  private final void handleInternal(int errorCode, String errorMessage) {
+  public final void handleInternal(int errorCode, String errorMessage) {
     try {
       handle(new MatterError(errorCode, errorMessage));
     } catch (Throwable t) {

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/SubscriptionEstablishedCallback.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/SubscriptionEstablishedCallback.java
@@ -24,7 +24,7 @@ public abstract class SubscriptionEstablishedCallback {
 
   public abstract void handle();
 
-  private void handleInternal() {
+  protected void handleInternal() {
     try {
       handle();
     } catch (Throwable t) {

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/SubscriptionEstablishedCallback.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/SubscriptionEstablishedCallback.java
@@ -24,7 +24,7 @@ public abstract class SubscriptionEstablishedCallback {
 
   public abstract void handle();
 
-  private void handleInternal() {
+  public void handleInternal() {
     try {
       handle();
     } catch (Throwable t) {

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/SubscriptionEstablishedCallback.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/SubscriptionEstablishedCallback.java
@@ -24,7 +24,7 @@ public abstract class SubscriptionEstablishedCallback {
 
   public abstract void handle();
 
-  public void handleInternal() {
+  private void handleInternal() {
     try {
       handle();
     } catch (Throwable t) {

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/SuccessCallback.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/SuccessCallback.java
@@ -24,7 +24,7 @@ public abstract class SuccessCallback<R> {
 
   public abstract void handle(R response);
 
-  private final void handleInternal(R response) {
+  protected final void handleInternal(R response) {
     try {
       handle(response);
     } catch (Throwable t) {

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/SuccessCallback.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/SuccessCallback.java
@@ -24,7 +24,7 @@ public abstract class SuccessCallback<R> {
 
   public abstract void handle(R response);
 
-  public final void handleInternal(R response) {
+  private final void handleInternal(R response) {
     try {
       handle(response);
     } catch (Throwable t) {

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/SuccessCallback.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/SuccessCallback.java
@@ -24,7 +24,7 @@ public abstract class SuccessCallback<R> {
 
   public abstract void handle(R response);
 
-  private final void handleInternal(R response) {
+  public final void handleInternal(R response) {
     try {
       handle(response);
     } catch (Throwable t) {

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/MatterCallbackHandler-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/MatterCallbackHandler-JNI.cpp
@@ -31,7 +31,10 @@ CHIP_ERROR CallbackBaseJNI::SetUp(JNIEnv * env, jobject inHandler)
     mClazz = env->GetObjectClass(mObject);
     VerifyOrExit(mClazz != nullptr, ChipLogError(AppServer, "Failed to get handler Java class"));
 
-    mMethod = env->GetMethodID(mClazz, "handleInternal", mMethodSignature);
+    mSuperClazz = env->GetSuperclass(mClazz);
+    VerifyOrExit(mSuperClazz != nullptr, ChipLogError(AppServer, "Failed to get handler's parent's Java class"));
+
+    mMethod = env->GetMethodID(mSuperClazz, "handleInternal", mMethodSignature);
     if (mMethod == nullptr)
     {
         ChipLogError(AppServer, "Failed to access 'handleInternal' method with signature %s", mMethodSignature);

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/MatterCallbackHandler-JNI.h
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/MatterCallbackHandler-JNI.h
@@ -37,6 +37,7 @@ public:
 protected:
     jobject mObject               = nullptr;
     jclass mClazz                 = nullptr;
+    jclass mSuperClazz            = nullptr;
     jmethodID mMethod             = nullptr;
     const char * mMethodSignature = nullptr;
 };


### PR DESCRIPTION
### Problem
On Android OS 8, we encountered the following errors (not seen before on other phones/versions of Android):

> 05-08 13:00:16.245 20360 20637 D SVR     : JNI_METHOD openBasicCommissioningWindow called with duration 60
05-08 13:00:16.245 20360 20637 D SVR     : CallbackBaseJNI::SetUp called
05-08 13:00:16.245 20360 20637 E SVR     : Failed to access 'handleInternal' method with signature (ILjava/lang/String;)V
05-08 13:00:16.245 20360 20637 D SVR     : CallbackBaseJNI::SetUp called
05-08 13:00:16.245 20360 20637 E SVR     : Failed to access 'handleInternal' method with signature (Ljava/lang/Object;)V
05-08 13:00:16.245 20360 20637 D SVR     : CallbackBaseJNI::SetUp called
05-08 13:00:16.245 20360 20637 E SVR     : Failed to access 'handleInternal' method with signature (ILjava/lang/String;)V
05-08 13:00:16.245 20360 20637 D SVR     : CallbackBaseJNI::SetUp called
05-08 13:00:16.245 20360 20637 E SVR     : Failed to access 'handleInternal' method with signature (Ljava/lang/Object;)V 

### Solution
The error is logged here in the SDK because the call to GetMethodId failed to find the method with the signatures mentioned above: https://github.com/project-chip/connectedhomeip/blob/master/examples/tv-casting-app/android/App/app/src/main/jni/cpp/MatterCallbackHandler-JNI.cpp#L34-L39

~~This change makes the handleInternal methods public (instead of private) which seems to fix the issue.~~

This change fetches the superclass of the Callback instance passed in by the tv-casting-app code and calls GetMethodId on that Superclass, rather than the Callback class itself. It also marks the handleInternal methods as "protected" instead of "private".


### Testing
Verified on the Android 8 test phone where the issue was encountered, by opening the commissioning window