### PR TITLE
Scheduling sending UDC requests off main thread

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -417,6 +417,10 @@ void Server::ScheduleFactoryReset()
 
 void Server::Shutdown()
 {
+    DeviceLayer::ChipDeviceEvent event;
+    event.Type = DeviceLayer::DeviceEventType::kServerShuttingDown;
+    chip::DeviceLayer::PlatformMgr().PostEvent(&event);
+
     mCASEServer.Shutdown();
     mCASESessionManager.Shutdown();
     app::DnssdServer::Instance().SetCommissioningModeProvider(nullptr);

--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -225,6 +225,11 @@ enum PublicEventTypes
      * Signals that the state of the OTA engine changed.
      */
     kOtaStateChanged,
+
+    /**
+     * Signals that the Server is Shutting down.
+     */
+    kServerShuttingDown,
 };
 
 /**

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -68,6 +68,12 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
 
     # Define the default number of ip addresses to discover
     chip_max_discovered_ip_addresses = 5
+
+    # Total number of UDC messages to be sent
+    chip_total_udc_message_count = 5
+
+    # Delay between sending repeated UDC messages (in ms)
+    chip_udc_message_delay_ms = 100
   }
 
   if (chip_stack_lock_tracking == "auto") {
@@ -287,6 +293,13 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
     if (chip_device_config_device_software_version_string != "") {
       defines += [ "CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING=\"${chip_device_config_device_software_version_string}\"" ]
     }
+
+    defines += [ "CHIP_DEVICE_CONFIG_MAX_DISCOVERED_IP_ADDRESSES=${chip_max_discovered_ip_addresses}" ]
+
+    defines += [
+      "CHIP_DEVICE_CONFIG_TOTAL_UDC_MSG_COUNT=${chip_total_udc_message_count}",
+      "CHIP_DEVICE_CONFIG_UDC_MSG_DELAY_MS=${chip_udc_message_delay_ms}",
+    ]
 
     defines += [ "CHIP_DEVICE_CONFIG_MAX_DISCOVERED_IP_ADDRESSES=${chip_max_discovered_ip_addresses}" ]
   }

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
@@ -89,6 +89,32 @@ public:
     virtual ~UserConfirmationProvider() = default;
 };
 
+/**
+ * Context used by the UserDirectedCommissioningClient for sending UDC messages
+ */
+struct UDCClientContext
+{
+    /**
+     * Number of UDC messages remaining to be sent
+     */
+    unsigned int mUdcAttemptsRemaining;
+
+    /**
+     * A transport to use for sending the message.
+     */
+    TransportMgrBase * mTransportMgr;
+
+    /**
+     * A PacketBufferHandle with the payload.
+     */
+    System::PacketBufferHandle mTargetPayload;
+
+    /**
+     * Address of destination.
+     */
+    chip::Transport::PeerAddress mTargetPeerAddress;
+};
+
 class DLL_EXPORT UserDirectedCommissioningClient
 {
 public:
@@ -107,8 +133,6 @@ public:
     CHIP_ERROR SendUDCMessage(TransportMgrBase * transportMgr, System::PacketBufferHandle && payload,
                               chip::Transport::PeerAddress peerAddress);
 
-    static void SendUDCTask(System::Layer * aSystemLayer, void * aAppState);
-
     /**
      * Encode a User Directed Commissioning message.
      *
@@ -122,10 +146,13 @@ public:
     CHIP_ERROR EncodeUDCMessage(const System::PacketBufferHandle & payload);
 
 private:
-    unsigned int mUdcAttemptsRemaining;
-    TransportMgrBase * mTransportMgr;
-    System::PacketBufferHandle mTargetPayload;
-    chip::Transport::PeerAddress mTargetPeerAddress;
+    /**
+     * A Task scheduled to send a UDC message as per the UDCClientContext passed in as aAppState
+     *
+     * @param aSystemLayer
+     * @param aAppState UDCClientContext used to send the UDC messages
+     */
+    static void SendUDCTask(System::Layer * aSystemLayer, void * aAppState);
 };
 
 class DLL_EXPORT UserDirectedCommissioningServer : public TransportMgrDelegate

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
@@ -107,6 +107,8 @@ public:
     CHIP_ERROR SendUDCMessage(TransportMgrBase * transportMgr, System::PacketBufferHandle && payload,
                               chip::Transport::PeerAddress peerAddress);
 
+    static void SendUDCTask(System::Layer * aSystemLayer, void * aAppState);
+
     /**
      * Encode a User Directed Commissioning message.
      *
@@ -118,6 +120,12 @@ public:
      */
 
     CHIP_ERROR EncodeUDCMessage(const System::PacketBufferHandle & payload);
+
+private:
+    unsigned int mUdcAttemptsRemaining;
+    TransportMgrBase * mTransportMgr;
+    System::PacketBufferHandle mTargetPayload;
+    chip::Transport::PeerAddress mTargetPeerAddress;
 };
 
 class DLL_EXPORT UserDirectedCommissioningServer : public TransportMgrDelegate

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioning.h
@@ -153,6 +153,14 @@ private:
      * @param aAppState UDCClientContext used to send the UDC messages
      */
     static void SendUDCTask(System::Layer * aSystemLayer, void * aAppState);
+
+    /**
+     * A callback to listen to CHIPDeviceEvents
+     *
+     * @param event A CHIPDeviceEvent
+     * @param arg UDCClientContext used to send the UDC messages
+     */
+    static void DeviceEventCallback(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
 };
 
 class DLL_EXPORT UserDirectedCommissioningServer : public TransportMgrDelegate


### PR DESCRIPTION
### Problem
The UserDirectedCommissioningClient sends the UDC message 5 times on the main thread. This blocks processing of subsequent requests/messages.

### Solution
Scheduled sending the UDC requests off the main thread.

### Testing
Tested on the the Android tv-casting-app with some debug logging (removed in this PR). 5 UDC requests are sent separated by ~100ms, after the sendUserDirectedCommissioning API returns.