### PR TITLE
Forcing FailSafe timer expiry when opening commisisoning window

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/ConnectionFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/ConnectionFragment.java
@@ -126,33 +126,40 @@ public class ConnectionFragment extends Fragment {
             new MatterCallbackHandler() {
               @Override
               public void handle(MatterError error) {
+                Log.d(TAG, "handle() called on CommissioningWindowOpened event with " + error);
+                if (error.isNoError()) {
+                  if (selectedCommissioner != null && selectedCommissioner.getNumIPs() > 0) {
+                    String ipAddress =
+                        selectedCommissioner.getIpAddresses().get(0).getHostAddress();
+                    Log.d(
+                        TAG,
+                        "ConnectionFragment calling tvCastingApp.sendUserDirectedCommissioningRequest with IP: "
+                            + ipAddress
+                            + " port: "
+                            + selectedCommissioner.getPort());
+
+                    sendUdcSuccess = tvCastingApp.sendCommissioningRequest(selectedCommissioner);
+                    updateUiOnConnectionSuccess();
+                  }
+                } else {
+                  getActivity()
+                      .runOnUiThread(
+                          () -> {
+                            commissioningWindowStatusView.setText(
+                                "Failed to open commissioning window");
+                          });
+                }
+              }
+            },
+            new MatterCallbackHandler() {
+              @Override
+              public void handle(MatterError error) {
                 Log.d(TAG, "handle() called on CommissioningComplete event with " + error);
               }
             },
             onConnectionSuccess,
             onConnectionFailure,
             onNewOrUpdatedEndpoints);
-
-    if (this.openCommissioningWindowSuccess) {
-      if (selectedCommissioner != null && selectedCommissioner.getNumIPs() > 0) {
-        String ipAddress = selectedCommissioner.getIpAddresses().get(0).getHostAddress();
-        Log.d(
-            TAG,
-            "ConnectionFragment calling tvCastingApp.sendUserDirectedCommissioningRequest with IP: "
-                + ipAddress
-                + " port: "
-                + selectedCommissioner.getPort());
-
-        this.sendUdcSuccess = tvCastingApp.sendCommissioningRequest(selectedCommissioner);
-        updateUiOnConnectionSuccess();
-      }
-    } else {
-      getActivity()
-          .runOnUiThread(
-              () -> {
-                commissioningWindowStatusView.setText("Failed to open commissioning window");
-              });
-    }
   }
 
   private void updateUiOnConnectionSuccess() {

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
@@ -181,6 +181,7 @@ public class TvCastingApp {
 
   public native boolean openBasicCommissioningWindow(
       int duration,
+      Object commissioningWindowOpenedHandler,
       Object commissioningCompleteHandler,
       SuccessCallback<VideoPlayer> onConnectionSuccess,
       FailureCallback onConnectionFailure,

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
@@ -113,13 +113,17 @@ JNI_METHOD(void, setDACProvider)(JNIEnv *, jobject, jobject provider)
 }
 
 JNI_METHOD(jboolean, openBasicCommissioningWindow)
-(JNIEnv * env, jobject, jint duration, jobject jCommissioningCompleteHandler, jobject jOnConnectionSuccessHandler,
- jobject jOnConnectionFailureHandler, jobject jOnNewOrUpdatedEndpointHandler)
+(JNIEnv * env, jobject, jint duration, jobject jCommissioningWindowOpenedHandler, jobject jCommissioningCompleteHandler,
+ jobject jOnConnectionSuccessHandler, jobject jOnConnectionFailureHandler, jobject jOnNewOrUpdatedEndpointHandler)
 {
     chip::DeviceLayer::StackLock lock;
 
     ChipLogProgress(AppServer, "JNI_METHOD openBasicCommissioningWindow called with duration %d", duration);
-    CHIP_ERROR err = TvCastingAppJNIMgr().getCommissioningCompleteHandler().SetUp(env, jCommissioningCompleteHandler);
+    CHIP_ERROR err = TvCastingAppJNIMgr().getCommissioningWindowOpenedHandler().SetUp(env, jCommissioningWindowOpenedHandler);
+    VerifyOrExit(CHIP_NO_ERROR == err,
+                 ChipLogError(AppServer, "MatterCallbackHandlerJNI::SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+    err = TvCastingAppJNIMgr().getCommissioningCompleteHandler().SetUp(env, jCommissioningCompleteHandler);
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "MatterCallbackHandlerJNI::SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
 
@@ -136,6 +140,7 @@ JNI_METHOD(jboolean, openBasicCommissioningWindow)
                  ChipLogError(AppServer, "OnNewOrUpdatedEndpointHandler.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
 
     err = CastingServer::GetInstance()->OpenBasicCommissioningWindow(
+        [](CHIP_ERROR err) { TvCastingAppJNIMgr().getCommissioningWindowOpenedHandler().Handle(err); },
         [](CHIP_ERROR err) { TvCastingAppJNIMgr().getCommissioningCompleteHandler().Handle(err); },
         [](TargetVideoPlayerInfo * videoPlayer) { TvCastingAppJNIMgr().getOnConnectionSuccessHandler(false).Handle(videoPlayer); },
         [](CHIP_ERROR err) { TvCastingAppJNIMgr().getOnConnectionFailureHandler(false).Handle(err); },

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.h
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.h
@@ -26,6 +26,7 @@
 class TvCastingAppJNI
 {
 public:
+    MatterCallbackHandlerJNI & getCommissioningWindowOpenedHandler() { return mCommissioningWindowOpenedHandler; }
     MatterCallbackHandlerJNI & getCommissioningCompleteHandler() { return mCommissioningCompleteHandler; }
     OnConnectionSuccessHandlerJNI & getOnConnectionSuccessHandler(bool preCommissioned)
     {
@@ -96,6 +97,7 @@ private:
 
     static TvCastingAppJNI sInstance;
 
+    MatterCallbackHandlerJNI mCommissioningWindowOpenedHandler;
     MatterCallbackHandlerJNI mCommissioningCompleteHandler;
     OnConnectionSuccessHandlerJNI mCommissioningOnConnectionSuccessHandler;
     FailureHandlerJNI mCommissioningOnConnectionFailureHandler;

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.h
@@ -123,11 +123,11 @@
  @param commissioningWindowOpenedCallback Callback to call after the opening of a commissioning window
  */
 - (void)openBasicCommissioningWindow:(dispatch_queue_t _Nonnull)clientQueue
-   commissioningWindowOpenedCallback:(void (^_Nonnull)(MatterError * _Nonnull))commissioningWindowOpenedCallback
-          commissioningCompleteCallback:(void (^_Nonnull)(MatterError * _Nonnull))commissioningCompleteCallback
-            onConnectionSuccessCallback:(void (^_Nonnull)(VideoPlayer * _Nonnull))onConnectionSuccessCallback
-            onConnectionFailureCallback:(void (^_Nonnull)(MatterError * _Nonnull))onConnectionFailureCallback
-         onNewOrUpdatedEndpointCallback:(void (^_Nonnull)(ContentApp * _Nonnull))onNewOrUpdatedEndpointCallback;
+    commissioningWindowOpenedCallback:(void (^_Nonnull)(MatterError * _Nonnull))commissioningWindowOpenedCallback
+        commissioningCompleteCallback:(void (^_Nonnull)(MatterError * _Nonnull))commissioningCompleteCallback
+          onConnectionSuccessCallback:(void (^_Nonnull)(VideoPlayer * _Nonnull))onConnectionSuccessCallback
+          onConnectionFailureCallback:(void (^_Nonnull)(MatterError * _Nonnull))onConnectionFailureCallback
+       onNewOrUpdatedEndpointCallback:(void (^_Nonnull)(ContentApp * _Nonnull))onNewOrUpdatedEndpointCallback;
 
 /*!
  @brief Gets the list of VideoPlayers currently connected

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.h
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.h
@@ -120,10 +120,10 @@
  @param onNewOrUpdatedEndpointCallback Handles a ContentApp * for each new ContentApp is found. May be called multiple times based
  on the number of ContentApp
 
- @param commissioningWindowRequestedHandler Handler to call on requesting the opening of a commissioning window
+ @param commissioningWindowOpenedCallback Callback to call after the opening of a commissioning window
  */
 - (void)openBasicCommissioningWindow:(dispatch_queue_t _Nonnull)clientQueue
-    commissioningWindowRequestedHandler:(void (^_Nonnull)(MatterError * _Nonnull))commissioningWindowRequestedHandler
+   commissioningWindowOpenedCallback:(void (^_Nonnull)(MatterError * _Nonnull))commissioningWindowOpenedCallback
           commissioningCompleteCallback:(void (^_Nonnull)(MatterError * _Nonnull))commissioningCompleteCallback
             onConnectionSuccessCallback:(void (^_Nonnull)(VideoPlayer * _Nonnull))onConnectionSuccessCallback
             onConnectionFailureCallback:(void (^_Nonnull)(MatterError * _Nonnull))onConnectionFailureCallback

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
@@ -591,10 +591,10 @@
 
 - (void)openBasicCommissioningWindow:(dispatch_queue_t _Nonnull)clientQueue
     commissioningWindowOpenedCallback:(void (^_Nonnull)(MatterError * _Nonnull))commissioningWindowOpenedCallback
-          commissioningCompleteCallback:(void (^_Nonnull)(MatterError * _Nonnull))commissioningCompleteCallback
-            onConnectionSuccessCallback:(void (^_Nonnull)(VideoPlayer * _Nonnull))onConnectionSuccessCallback
-            onConnectionFailureCallback:(void (^_Nonnull)(MatterError * _Nonnull))onConnectionFailureCallback
-         onNewOrUpdatedEndpointCallback:(void (^_Nonnull)(ContentApp * _Nonnull))onNewOrUpdatedEndpointCallback
+        commissioningCompleteCallback:(void (^_Nonnull)(MatterError * _Nonnull))commissioningCompleteCallback
+          onConnectionSuccessCallback:(void (^_Nonnull)(VideoPlayer * _Nonnull))onConnectionSuccessCallback
+          onConnectionFailureCallback:(void (^_Nonnull)(MatterError * _Nonnull))onConnectionFailureCallback
+       onNewOrUpdatedEndpointCallback:(void (^_Nonnull)(ContentApp * _Nonnull))onNewOrUpdatedEndpointCallback
 {
     [self
         dispatchOnMatterSDKQueue:@"openBasicCommissioningWindow(...)"
@@ -606,7 +606,7 @@
                                                      description:
                                                          @"openBasicCommissioningWindow(...) commissioningWindowRequestedCallback"
                                                            block:^{
-                                                                commissioningWindowOpenedCallback([[MatterError alloc]
+                                                               commissioningWindowOpenedCallback([[MatterError alloc]
                                                                    initWithCode:err.AsInteger()
                                                                         message:[NSString stringWithUTF8String:err.AsString()]]);
                                                            }];

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/CommissioningViewModel.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/CommissioningViewModel.swift
@@ -41,55 +41,46 @@ class CommissioningViewModel: ObservableObject {
                     self.Log.info("CommissioningViewModel.setDacHolder status was \(error)")
                     if(error.code == 0)
                     {
-                        self.openBasicCommissioningWindow()
+                        castingServerBridge.openBasicCommissioningWindow(DispatchQueue.main,
+                            commissioningWindowOpenedCallback: { (result: MatterError) -> () in
+                                DispatchQueue.main.async {
+                                    self.commisisoningWindowOpened = (result.code == 0)
+                                    // Send User directed commissioning request if a commissioner with a known IP addr was selected
+                                    if(selectedCommissioner != nil && selectedCommissioner!.numIPs > 0)
+                                    {
+                                        self.sendUserDirectedCommissioningRequest(selectedCommissioner: selectedCommissioner)
+                                    }
+                                }
+                            },
+                            commissioningCompleteCallback: { (result: MatterError) -> () in
+                                self.Log.info("Commissioning status: \(result)")
+                                DispatchQueue.main.async {
+                                    self.commisisoningComplete = (result.code == 0)
+                                }
+                            },
+                            onConnectionSuccessCallback: { (videoPlayer: VideoPlayer) -> () in
+                                DispatchQueue.main.async {
+                                    self.connectionSuccess = true
+                                    self.connectionStatus = "Connected to \(String(describing: videoPlayer))"
+                                    self.Log.info("CommissioningViewModel.verifyOrEstablishConnection.onConnectionSuccessCallback called with \(videoPlayer.nodeId)")
+                                }
+                            },
+                            onConnectionFailureCallback: { (error: MatterError) -> () in
+                                DispatchQueue.main.async {
+                                    self.connectionSuccess = false
+                                    self.connectionStatus = "Failed to connect to video player!"
+                                    self.Log.info("CommissioningViewModel.verifyOrEstablishConnection.onConnectionFailureCallback called with \(error)")
+                                }
+                            },
+                            onNewOrUpdatedEndpointCallback: { (contentApp: ContentApp) -> () in
+                                DispatchQueue.main.async {
+                                    self.Log.info("CommissioningViewModel.openBasicCommissioningWindow.onNewOrUpdatedEndpointCallback called with \(contentApp.endpointId)")
+                                }
+                            })
                     }
                 }
             })
         }
-                
-        // Send User directed commissioning request if a commissioner with a known IP addr was selected
-        if(selectedCommissioner != nil && selectedCommissioner!.numIPs > 0)
-        {
-            sendUserDirectedCommissioningRequest(selectedCommissioner: selectedCommissioner)
-        }
-    }
-    
-    private func openBasicCommissioningWindow() {
-        if let castingServerBridge = CastingServerBridge.getSharedInstance()
-        {
-            castingServerBridge.openBasicCommissioningWindow(DispatchQueue.main,
-                commissioningWindowRequestedHandler: { (result: MatterError) -> () in
-                    DispatchQueue.main.async {
-                        self.commisisoningWindowOpened = (result.code == 0)
-                    }
-                },
-                commissioningCompleteCallback: { (result: MatterError) -> () in
-                    self.Log.info("Commissioning status: \(result)")
-                    DispatchQueue.main.async {
-                        self.commisisoningComplete = (result.code == 0)
-                    }
-                },
-                onConnectionSuccessCallback: { (videoPlayer: VideoPlayer) -> () in
-                    DispatchQueue.main.async {
-                        self.connectionSuccess = true
-                        self.connectionStatus = "Connected to \(String(describing: videoPlayer))"
-                        self.Log.info("CommissioningViewModel.verifyOrEstablishConnection.onConnectionSuccessCallback called with \(videoPlayer.nodeId)")
-                    }
-                },
-                onConnectionFailureCallback: { (error: MatterError) -> () in
-                    DispatchQueue.main.async {
-                        self.connectionSuccess = false
-                        self.connectionStatus = "Failed to connect to video player!"
-                        self.Log.info("CommissioningViewModel.verifyOrEstablishConnection.onConnectionFailureCallback called with \(error)")
-                    }
-                },
-                onNewOrUpdatedEndpointCallback: { (contentApp: ContentApp) -> () in
-                    DispatchQueue.main.async {
-                        self.Log.info("CommissioningViewModel.openBasicCommissioningWindow.onNewOrUpdatedEndpointCallback called with \(contentApp.endpointId)")
-                    }
-                })
-        }
-        
     }
     
     private func sendUserDirectedCommissioningRequest(selectedCommissioner: DiscoveredNodeData?) {        

--- a/examples/tv-casting-app/linux/CastingUtils.cpp
+++ b/examples/tv-casting-app/linux/CastingUtils.cpp
@@ -62,26 +62,27 @@ void PrepareForCommissioning(const Dnssd::DiscoveredNodeData * selectedCommissio
 {
     CastingServer::GetInstance()->Init();
 
-    CastingServer::GetInstance()->OpenBasicCommissioningWindow(HandleCommissioningCompleteCallback, OnConnectionSuccess,
-                                                               OnConnectionFailure, OnNewOrUpdatedEndpoint);
+    CastingServer::GetInstance()->OpenBasicCommissioningWindow(
+        [selectedCommissioner](CHIP_ERROR err) {
+#if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
+            if (selectedCommissioner != nullptr)
+            {
+                // Send User Directed commissioning request
+                // Wait 1 second to allow our commissionee DNS records to publish (needed on Mac)
+                int32_t expiration = 1;
+                ReturnOnFailure(DeviceLayer::SystemLayer().StartTimer(System::Clock::Seconds32(expiration), HandleUDCSendExpiration,
+                                                                      (void *) selectedCommissioner));
+            }
+            else
+            {
+                ChipLogProgress(AppServer, "To run discovery again, enter: cast discover");
+            }
+#endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
+        },
+        HandleCommissioningCompleteCallback, OnConnectionSuccess, OnConnectionFailure, OnNewOrUpdatedEndpoint);
 
     // Display onboarding payload
     chip::DeviceLayer::ConfigurationMgr().LogDeviceConfig();
-
-#if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
-    if (selectedCommissioner != nullptr)
-    {
-        // Send User Directed commissioning request
-        // Wait 1 second to allow our commissionee DNS records to publish (needed on Mac)
-        int32_t expiration = 1;
-        ReturnOnFailure(DeviceLayer::SystemLayer().StartTimer(System::Clock::Seconds32(expiration), HandleUDCSendExpiration,
-                                                              (void *) selectedCommissioner));
-    }
-    else
-    {
-        ChipLogProgress(AppServer, "To run discovery again, enter: cast discover");
-    }
-#endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
 }
 
 void InitCommissioningFlow(intptr_t commandArg)

--- a/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
@@ -61,7 +61,8 @@ public:
     CHIP_ERROR StopDiscoverCommissioners();
     const chip::Dnssd::DiscoveredNodeData *
     GetDiscoveredCommissioner(int index, chip::Optional<TargetVideoPlayerInfo *> & outAssociatedConnectableVideoPlayer);
-    CHIP_ERROR OpenBasicCommissioningWindow(std::function<void(CHIP_ERROR)> commissioningCompleteCallback,
+    CHIP_ERROR OpenBasicCommissioningWindow(std::function<void(CHIP_ERROR)> commissioningWindowOpenedCallback,
+                                            std::function<void(CHIP_ERROR)> commissioningCompleteCallback,
                                             std::function<void(TargetVideoPlayerInfo *)> onConnectionSuccess,
                                             std::function<void(CHIP_ERROR)> onConnectionFailure,
                                             std::function<void(TargetEndpointInfo *)> onNewOrUpdatedEndpoint);
@@ -457,6 +458,7 @@ private:
     chip::Inet::IPAddress mTargetVideoPlayerIpAddress[chip::Dnssd::CommonResolutionData::kMaxIPAddresses];
 
     chip::Controller::CommissionableNodeController mCommissionableNodeController;
+    std::function<void(CHIP_ERROR)> mCommissioningWindowOpenedCallback;
     std::function<void(CHIP_ERROR)> mCommissioningCompleteCallback;
 
     std::function<void(TargetEndpointInfo *)> mOnNewOrUpdatedEndpoint;

--- a/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
@@ -424,6 +424,8 @@ private:
 
     CHIP_ERROR SetRotatingDeviceIdUniqueId(chip::Optional<chip::ByteSpan> rotatingDeviceIdUniqueId);
 
+    static void OpenBasicCommissioningWindowTask(chip::System::Layer * aSystemLayer, void * aAppState);
+
     static void DeviceEventCallback(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
     void ReadServerClusters(chip::EndpointId endpointId);
 
@@ -441,8 +443,9 @@ private:
     static chip::Inet::IPAddress * getIpAddressForUDCRequest(chip::Inet::IPAddress ipAddresses[], const size_t numIPs);
 
     PersistenceManager mPersistenceManager;
-    bool mInited        = false;
-    bool mUdcInProgress = false;
+    bool mInited                              = false;
+    bool mUdcInProgress                       = false;
+    bool mOpenBasicCommissioningWindowPending = false;
     TargetVideoPlayerInfo mActiveTargetVideoPlayerInfo;
     TargetVideoPlayerInfo mCachedTargetVideoPlayerInfo[kMaxCachedVideoPlayers];
     uint16_t mTargetVideoPlayerVendorId                                   = 0;

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -480,7 +480,7 @@ void CastingServer::DeviceEventCallback(const DeviceLayer::ChipDeviceEvent * eve
     else if (event->Type == DeviceLayer::DeviceEventType::kFailSafeTimerExpired &&
              CastingServer::GetInstance()->mOpenBasicCommissioningWindowPending)
     {
-        DeviceLayer::SystemLayer().StartTimer(System::Clock::Milliseconds32(50), OpenBasicCommissioningWindowTask, nullptr);
+        DeviceLayer::SystemLayer().StartTimer(System::Clock::Milliseconds32(1), OpenBasicCommissioningWindowTask, nullptr);
         CastingServer::GetInstance()->mOpenBasicCommissioningWindowPending = false;
     }
 


### PR DESCRIPTION
### Problem
Sometimes a commissioner (TV) may **abandon** commissioning (different from erroring out) of the tv-casting-app midway through. If a failsafe was armed by the commissioner with a certain expiry time, in such a case, the tv-casting-app is unable to begin a new user directed commissioning session right away. This causes an undesirable CX where the customer may have to wait for the failsafe timer to expire (which can be too long, running longer than a minute).

### Change summary
In this change, before opening the commissioning window, we check if a failsafe is armed already. If it is, we force the failsafe timer to expire by calling ForceFailSafeTimerExpiry, wait for the kFailSafeTimerExpired event, and then attempt to open the commissioning window.
With this change, the Android tv-casting-app implements a commisisoningWindowOpenedCallback/Handler where it calls the sendUDC API.

### Testing
Tested with the iOS tv-casting-app