### PR TITLE
Update KeyValueStoreManagerImpl::Init to return error instead of calling chipDie on error adding persistent store

### DIFF
--- a/src/platform/Darwin/KeyValueStoreManagerImpl.mm
+++ b/src/platform/Darwin/KeyValueStoreManagerImpl.mm
@@ -197,7 +197,7 @@ namespace DeviceLayer {
                                                      options:nil
                                                        error:&error]) {
                     ChipLogError(DeviceLayer, "Failed to initialize clear KVS storage: %s", error.localizedDescription.UTF8String);
-                    chipDie();
+                    return CHIP_ERROR_INTERNAL;
                 }
             }
 


### PR DESCRIPTION
There's a use-case in which the Matter server needs to be running within an iOS app that leverages Matter casting. There are scenarios in which a user device may be out of disk storage or some other permission related issue that can lead the addPersistentStoreWithType to return an error. This was causing the application to crash due to the call to chipDie. Instead of killing the app, the function, similarly on how it handles other errors, to return a CHIP_ERROR_INTERNAL so that the initialization of the Matter stack would fail indicating to the app that it should not enable Matter support for this instance instead of just crashing.

