### PR TITLE
Adding defensive asserts in APIs to ensure CastingServer/Bridge is in the correct state

### DIFF
--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
@@ -104,6 +104,8 @@
         _subscriptionReadFailureCallbacks = [NSMutableDictionary dictionary];
         _readSuccessCallbacks = [NSMutableDictionary dictionary];
         _readFailureCallbacks = [NSMutableDictionary dictionary];
+
+        _chipWorkQueue = chip::DeviceLayer::PlatformMgrImpl().GetWorkQueue();
     }
     return self;
 }
@@ -363,8 +365,6 @@
         ChipLogError(AppServer, "chip::Server init failed: %s", ErrorStr(err));
         return [[MatterError alloc] initWithCode:err.AsInteger() message:[NSString stringWithUTF8String:err.AsString()]];
     }
-
-    _chipWorkQueue = chip::DeviceLayer::PlatformMgrImpl().GetWorkQueue();
 
     chip::DeviceLayer::PlatformMgrImpl().StartEventLoopTask();
 

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
@@ -116,6 +116,11 @@
  */
 - (void)dispatchOnMatterSDKQueue:(const NSString * _Nullable)description block:(dispatch_block_t)block
 {
+    if (_chipWorkQueue == nullptr) {
+        ChipLogError(AppServer, "CastingServerBridge().dispatchOnMatterSDKQueue() chipWorkQueue uninitialized. Cannot dispatch");
+        return;
+    }
+
     if (nil != description) {
         ChipLogProgress(AppServer, "[SYNC] CastingServerBridge %s", [description UTF8String]);
     }
@@ -148,6 +153,11 @@
                   description:(const NSString * _Nullable)description
                         block:(dispatch_block_t)block
 {
+    if (_chipWorkQueue == nullptr) {
+        ChipLogError(AppServer, "CastingServerBridge().dispatchOnMatterSDKQueue() chipWorkQueue uninitialized. Cannot dispatch");
+        return;
+    }
+
     // Within the CastingServerBridge, the usage pattern is typically to expose asynchronous public APIs that
     // take a callback to indicate that the low-level SDK operation has been initiated (the "started"
     // callback), and a separate set of result callbacks to be invoked when the low-level SDK operation
@@ -270,7 +280,7 @@
     // Note that it is presently safe to do at this point because InitChipStack is called in the
     // constructor for the CastingServerBridge.
     chip::DeviceLayer::StackLock lock;
-    ChipLogProgress(AppServer, "CastingServerBridge().initApp() called");
+    ChipLogProgress(AppServer, "CastingServerBridge().initializeApp() called");
 
     CHIP_ERROR err = CHIP_NO_ERROR;
     _commissionableDataProvider = new CommissionableDataProviderImpl();


### PR DESCRIPTION
### Problem

The iOS tv-casting-app can crash if ShutdownAllSubscriptions is called before initializeApp returns successfully. See crash below:

```
Crashed: com.apple.main-thread
0  libdispatch.dylib              0x3d118 dispatch_async$VARIANT$armv81 + 148
1  MatterTvCastingBridge          0x6a64 -[CastingServerBridge dispatchOnMatterSDKQueue:block:] + 344
2  MatterTvCastingBridge          0xcf78 -[CastingServerBridge shutdownAllSubscriptions:requestSentHandler:] + 196
3  PrimeVideo-Beta                0x42ac3c SecondScreenMatterSubscriptionManager.shutDownAllSubscriptions(removeAll:reason:) + 63 (SecondScreenMatterSubscriptionManager.swift:63)
4  PrimeVideo-Beta                0xb28f24 SecondScreenMatterContext.onAppWillResignActive() + 41 (SecondScreenMatterContext.swift:41)
5  PrimeVideo-Beta                0x27e2b8 @objc SecondScreenContext.onAppWillResignActive() + 71 (SecondScreenContext.swift:71)
6  PrimeVideo-Beta                0x11ce064 -[AIVLifecycleManager applicationWillResignActive:] + 176 (AIVLifecycleManager.m:176)
7  PrimeVideo-Beta                0xef203c -[AIVAppDelegate applicationWillResignActive:] + 405 (AIVAppDelegate.m:405)

```

The crash occurs here: https://github.com/sharadb-amazon/connectedhomeip/blob/v1.0.0-branch/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm#L122 in dispatchOnMatterSDKQueue(). It looks like _chipWorkQueue was somehow nullptr when dispatching in the case this crash happened.

### Change summary
1. Initializing _chipWorkQueue earlier, in the CastingServerBridge.init() method
2. Asserting _chipWorkQueue is non-nil in dispatchOn*Queue() functions before attempting to dispatch on it.
3. Asserting CastingServer is mInited at the top of all its public APIs.

### Testing
Tested using the iOS tv-casting-app and Linux tv-app