### PR TITLE
iOS tv-casting-app: cancelDiscoveryCommissionersWork should be dispatched on the chipWorkQueue (not clientQueue)

### DIFF
--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
@@ -104,7 +104,7 @@
         _subscriptionReadFailureCallbacks = [NSMutableDictionary dictionary];
         _readSuccessCallbacks = [NSMutableDictionary dictionary];
         _readFailureCallbacks = [NSMutableDictionary dictionary];
-        
+
         _chipWorkQueue = chip::DeviceLayer::PlatformMgrImpl().GetWorkQueue();
     }
     return self;
@@ -465,8 +465,8 @@
                                                CastingServer::GetInstance()->StopDiscoverCommissioners();
                                                self->_cancelDiscoveryCommissionersWork = nil;
                                            });
-                                     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, timeoutInSeconds * NSEC_PER_SEC), self->_chipWorkQueue,
-                                         self->_cancelDiscoveryCommissionersWork);
+                                     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, timeoutInSeconds * NSEC_PER_SEC),
+                                         self->_chipWorkQueue, self->_cancelDiscoveryCommissionersWork);
                                  }
 
                                  dispatch_async(clientQueue, ^{
@@ -835,6 +835,12 @@
     [self
         dispatchOnMatterSDKQueue:@"stopMatterServer(...)"
                            block:^{
+                               if (self->_cancelDiscoveryCommissionersWork
+                                   && dispatch_block_testcancel(self->_cancelDiscoveryCommissionersWork) == 0) {
+                                   dispatch_block_cancel(self->_cancelDiscoveryCommissionersWork);
+                                   self->_cancelDiscoveryCommissionersWork = nil;
+                               }
+
                                // capture pointer to previouslyConnectedVideoPlayer, to be deleted
                                TargetVideoPlayerInfo * videoPlayerForDeletion
                                    = self->_previouslyConnectedVideoPlayer == nil ? nil : self->_previouslyConnectedVideoPlayer;

--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
@@ -104,6 +104,8 @@
         _subscriptionReadFailureCallbacks = [NSMutableDictionary dictionary];
         _readSuccessCallbacks = [NSMutableDictionary dictionary];
         _readFailureCallbacks = [NSMutableDictionary dictionary];
+        
+        _chipWorkQueue = chip::DeviceLayer::PlatformMgrImpl().GetWorkQueue();
     }
     return self;
 }
@@ -463,7 +465,7 @@
                                                CastingServer::GetInstance()->StopDiscoverCommissioners();
                                                self->_cancelDiscoveryCommissionersWork = nil;
                                            });
-                                     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, timeoutInSeconds * NSEC_PER_SEC), clientQueue,
+                                     dispatch_after(dispatch_time(DISPATCH_TIME_NOW, timeoutInSeconds * NSEC_PER_SEC), self->_chipWorkQueue,
                                          self->_cancelDiscoveryCommissionersWork);
                                  }
 


### PR DESCRIPTION
### Problem

This commit 2d5f022 introduced a way to time the discovery process out on the iOS tv-casting-app. However, it dispatched the cancelDiscoveryCommissionersWork on the clientQueue. This is incorrect, as that is interacting with the CastingServer.

Additionally, the cancelDiscoveryCommissionersWork needs to be cleaned up (canceled, nil'ed) when stopMatterServer is called.

### Solution

Initialized the chipWorkQueue earlier, in the CastingServerBridge.init(), and dispatched cancelDiscoveryCommissionersWork on the chipWorkQueue instead.

### Testing

Tested with the iOS tv-casting-app