### PR TITLE
Fixing build error due to unused mTimeSource

### DIFF
--- a/src/app/server/Dnssd.h
+++ b/src/app/server/Dnssd.h
@@ -130,8 +130,6 @@ private:
     //
     bool HaveOperationalCredentials();
 
-    Time::TimeSource<Time::Source::kSystem> mTimeSource;
-
     FabricTable * mFabricTable                             = nullptr;
     CommissioningModeProvider * mCommissioningModeProvider = nullptr;
 
@@ -143,6 +141,8 @@ private:
     Optional<uint16_t> mEphemeralDiscriminator;
 
 #if CHIP_DEVICE_CONFIG_ENABLE_EXTENDED_DISCOVERY
+    Time::TimeSource<Time::Source::kSystem> mTimeSource;
+
     /// Get the current extended discovery timeout (set by
     /// SetExtendedDiscoveryTimeoutSecs, or the configuration default if not set).
     int32_t GetExtendedDiscoveryTimeoutSecs();


### PR DESCRIPTION
### Problem

Without this fix, the build of the Android tv-casting-app fails with the following error since CHIP_DEVICE_CONFIG_ENABLE_EXTENDED_DISCOVERY was disabled.

```
../../examples/tv-casting-app/android/third_party/connectedhomeip/src/app/server/Dnssd.h:133:45: error: private field 'mTimeSource' is not used [-Werror,-Wunused-private-field]
2023-06-28 11:25:49 INFO        Time::TimeSource<Time::Source::kSystem> mTimeSource;
```

### Solution
Moved the mTimeSource data member to be inside an #if CHIP_DEVICE_CONFIG_ENABLE_EXTENDED_DISCOVERY statement.

### Testing
Build and ran the android tv-casting-app successfully after this change