### PR TITLE
tv-casting-app: Increasing EMBER_BINDING_TABLE_SIZE from 10 to 64

### DIFF
--- a/zzz_generated/tv-casting-app/zap-generated/gen_config.h
+++ b/zzz_generated/tv-casting-app/zap-generated/gen_config.h
@@ -21,7 +21,7 @@
 #pragma once
 
 // User options for plugin Binding Table Library
-#define EMBER_BINDING_TABLE_SIZE 10
+#define EMBER_BINDING_TABLE_SIZE 64
 
 /**** Network Section ****/
 #define EMBER_SUPPORTED_NETWORKS (1)


### PR DESCRIPTION
### Problem

If the tv-casting-app is commissioned by many Matter TVs, it seems it can run out of space in the Binding table that is cached on disk. This leads to issues during commissioning where the app does not find a nodeId corresponding to a fabricIndex because the binding table overflowed.

### Change summary
Increased EMBER_BINDING_TABLE_SIZE from 10 to 64

### Testing
Built and tested with the iOS tv-casting-app against the Linux tv-app