### PR TITLE
tv-casting-app: fix TargetVideoPlayerInfo mem corruption

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
@@ -140,7 +140,20 @@ public class TvCastingApp {
       }
 
       List<VideoPlayer> preCommissionedVideoPlayers = readCachedVideoPlayers();
-
+      if (preCommissionedVideoPlayers != null) {
+        for (VideoPlayer videoPlayer : preCommissionedVideoPlayers) {
+          Log.d(
+              TAG,
+              "preCommissionedVideoPlayer hostName: "
+                  + videoPlayer.getHostName()
+                  + " MACAddress: "
+                  + videoPlayer.getMACAddress()
+                  + " numIPs: "
+                  + videoPlayer.getNumIPs()
+                  + " IP Addresses: "
+                  + videoPlayer.getIpAddresses());
+        }
+      }
       WifiManager wifiManager =
           (WifiManager) applicationContext.getSystemService(Context.WIFI_SERVICE);
       multicastLock = wifiManager.createMulticastLock("multicastLock");

--- a/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
@@ -446,6 +446,7 @@ private:
 
     static void VerifyOrEstablishConnectionTask(chip::System::Layer * aSystemLayer, void * context);
     CHIP_ERROR ReadMACAddress(TargetEndpointInfo * endpoint);
+    int GetCachedVideoPlayerIndex(TargetVideoPlayerInfo * targetVideoPlayerInfo);
 
     /**
      * @brief Retrieve the IP Address to use for the UDC request.


### PR DESCRIPTION
### Problem

The IPAddress and MACAddress fields (in the TargetVideoPlayerInfo), required for the WakeOnLAN implementation, were sometimes getting corrupted when the VerifyOrEstablishConnectionTask() API is called. This was because the VerifyOrEstablishConnection() API gets a reference to the targetVideoPlayerInfo that is created on the stack by the caller. If we copy the input param targetVideoPlayerInfo to the mActiveTargetVideoPlayerInfo, the underlying memory for the IPAddress and MACAddress may get deallocated as the original targetVideoPlayerInfo goes out of scope of the caller.

### Solution
Find the index of the targetVideoPlayerInfo in the mCachedTargetVideoPlayerInfo array that is held in the CastingServer class as a data member. Then copy the cached equivalent of the targetVideoPlayerInfo to mActiveTargetVideoPlayerInfo. This way the memory locations the mActiveTargetVideoPlayerInfo stays valid during a connection attempt, as the mCachedTargetVideoPlayerInfo[] is a CastingServer class data member.

### Testing
Tested using the android tv-casting-app running against the Linux tv-app and checked that the IP Address and MAC Address fields now stay valid.